### PR TITLE
[Nexus-1515] Bug: Selected Tab is not Reactive

### DIFF
--- a/src/views/repository/content/BasesForm.vue
+++ b/src/views/repository/content/BasesForm.vue
@@ -74,7 +74,7 @@
           <template v-if="isRouterView">
             <UnnnicTab
               :tabs="routerTabs.map((e) => e.page)"
-              :initialTab="routerTabs.find((e) => e.page === $route.name).page"
+              :activeTab="routerTabs.find((e) => e.page === $route.name).page"
               @change="onTabChange"
             >
               <template v-for="tab in routerTabs">


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When the user clicks to activate Brain, they are redirected to the tunings tab, but the appearance of the selected tab is not changed.

### Summary of Changes
<!--- Describe your changes in detail -->
* Uses UnnnicTab `activeTab` prop to use reactive selected tab.

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
![image](https://github.com/weni-ai/intelligence-webapp/assets/6540136/aff536ea-afb0-4ad3-8245-d6bca53633eb)
