### PR TITLE
[Nexus-1744] Process of Deprecating the Content Bases: Hide List Filter Option

### DIFF
--- a/src/components/intelligences/IntelligencesFilter.vue
+++ b/src/components/intelligences/IntelligencesFilter.vue
@@ -7,6 +7,7 @@
     <UnnnicSelectSmart
       v-if="category !== undefined"
       size="sm"
+      data-test="category-select"
       :modelValue="category"
       :options="categories"
       @update:model-value="$emit('update:category', $event)"
@@ -17,25 +18,38 @@
       :modelValue="name"
       size="sm"
       iconLeft="search-1"
+      data-test="name-input"
       :placeholder="$t('intelligences.search_intelligence_placeholder')"
       @update:model-value="$emit('update:name', $event)"
     />
 
-    <UnnnicRadio
-      :modelValue="type"
-      value="generative"
-      @update:modelValue="$emit('update:type', $event)"
-    >
-      {{ $t('intelligences.filter_type_generative_label') }}
-    </UnnnicRadio>
+    <UnnnicSkeletonLoading
+      v-if="loadingType"
+      tag="div"
+      width="310px"
+      height="22px"
+      data-test="types-skeleton-loading"
+    />
 
-    <UnnnicRadio
-      :modelValue="type"
-      value="classification"
-      @update:modelValue="$emit('update:type', $event)"
-    >
-      {{ $t('intelligences.filter_type_classification_label') }}
-    </UnnnicRadio>
+    <template v-else-if="showTypes">
+      <UnnnicRadio
+        :modelValue="type"
+        value="generative"
+        data-test="generative-radio"
+        @update:model-value="$emit('update:type', $event)"
+      >
+        {{ $t('intelligences.filter_type_generative_label') }}
+      </UnnnicRadio>
+
+      <UnnnicRadio
+        :modelValue="type"
+        value="classification"
+        data-test="classification-radio"
+        @update:model-value="$emit('update:type', $event)"
+      >
+        {{ $t('intelligences.filter_type_classification_label') }}
+      </UnnnicRadio>
+    </template>
   </div>
 </template>
 
@@ -44,14 +58,26 @@ import { mapActions } from 'vuex';
 
 export default {
   props: {
-    name: String,
-    type: String,
-    category: Array,
+    category: {
+      type: Array,
+      default: undefined,
+    },
+    name: {
+      type: String,
+      default: '',
+    },
+    type: {
+      type: String,
+      default: '',
+    },
+    loadingType: Boolean,
+    showTypes: {
+      type: Boolean,
+      default: true,
+    },
   },
 
-  data() {
-    return {};
-  },
+  emits: ['update:category', 'update:name', 'update:type'],
 
   computed: {
     categories() {
@@ -60,16 +86,18 @@ export default {
         label: this.$t('intelligences.categories_placeholder'),
       };
 
+      const options = [placeholder];
+
       if (this.$store.state.Category.allCategories) {
-        return [placeholder].concat(
-          this.$store.state.Category.allCategories.map((category) => ({
+        options.push(
+          ...this.$store.state.Category.allCategories.map((category) => ({
             value: category.id,
             label: category.name,
           })),
         );
       }
 
-      return [placeholder];
+      return options;
     },
   },
 

--- a/src/components/intelligences/__tests__/IntelligencesFilter.unit.spec.js
+++ b/src/components/intelligences/__tests__/IntelligencesFilter.unit.spec.js
@@ -1,0 +1,165 @@
+import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import IntelligencesFilter from '@/components/intelligences/IntelligencesFilter.vue';
+
+const elements = {
+  categorySelect: '[data-test="category-select"]',
+  nameInput: '[data-test="name-input"]',
+  typesSkeletonLoading: '[data-test="types-skeleton-loading"]',
+  generativeRadio: '[data-test="generative-radio"]',
+  classificationRadio: '[data-test="classification-radio"]',
+};
+
+const store = createStore({
+  state() {
+    return {
+      Category: {
+        allCategories: [
+          { id: 1, name: 'Social', icon: 'social' },
+          { id: 2, name: 'Service', icon: 'customer-service' },
+          { id: 3, name: 'Configuration', icon: 'config' },
+        ],
+      },
+    };
+  },
+
+  actions: {
+    getAllCategories: vi.fn(),
+  },
+});
+
+const setup = ({ category, loadingType, showTypes } = {}) =>
+  mount(IntelligencesFilter, {
+    props: {
+      category,
+      loadingType,
+      showTypes,
+    },
+
+    global: {
+      plugins: [store],
+    },
+  });
+
+describe('IntelligencesFilter.vue', () => {
+  let wrapper;
+
+  it('', () => {
+    wrapper = setup();
+  });
+
+  describe('when category is not set', () => {
+    it('should not show the category select', () => {
+      wrapper = setup({ category: undefined });
+
+      expect(wrapper.find(elements.categorySelect).exists()).toBeFalsy();
+    });
+  });
+
+  describe('when category is set', () => {
+    it('should show the category select', () => {
+      wrapper = setup({ category: [] });
+
+      expect(wrapper.find(elements.categorySelect).exists()).toBeTruthy();
+    });
+
+    describe('when the user changes the category', () => {
+      it('emits update:category', () => {
+        wrapper = setup({ category: [] });
+
+        const categorySelect = wrapper.findComponent(elements.categorySelect);
+
+        categorySelect.vm.$emit('update:modelValue', [
+          { value: 2, label: 'Service' },
+        ]);
+
+        const updateCategoryEmit = wrapper.emitted('update:category');
+
+        expect(updateCategoryEmit).toHaveLength(1);
+        expect(updateCategoryEmit[0]).toEqual([
+          [{ value: 2, label: 'Service' }],
+        ]);
+      });
+    });
+  });
+
+  describe('when the user changes the name filter', () => {
+    it('emits update:name', () => {
+      wrapper = setup();
+
+      const nameInput = wrapper.findComponent(elements.nameInput);
+
+      nameInput.vm.$emit('update:modelValue', 'Intelligence Name');
+
+      const updateNameEmit = wrapper.emitted('update:name');
+
+      expect(updateNameEmit).toHaveLength(1);
+      expect(updateNameEmit[0]).toEqual(['Intelligence Name']);
+    });
+  });
+
+  describe('when type is loading', () => {
+    it('shows types skeleton loading', () => {
+      wrapper = setup({ loadingType: true });
+
+      expect(
+        wrapper.findComponent(elements.typesSkeletonLoading).exists(),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('when type is not loading', () => {
+    it('shows types skeleton loading', () => {
+      wrapper = setup();
+
+      expect(
+        wrapper.findComponent(elements.typesSkeletonLoading).exists(),
+      ).toBeFalsy();
+    });
+
+    it('shows types radios', () => {
+      wrapper = setup();
+
+      expect(
+        wrapper.findComponent(elements.generativeRadio).exists(),
+      ).toBeTruthy();
+
+      expect(
+        wrapper.findComponent(elements.classificationRadio).exists(),
+      ).toBeTruthy();
+    });
+
+    describe.each([
+      { radio: elements.generativeRadio, expectedValue: 'generative' },
+      { radio: elements.classificationRadio, expectedValue: 'classification' },
+    ])(
+      'when the user clicks on $expectedValue radio',
+      ({ radio, expectedValue }) => {
+        it(`emits update:type with value ${expectedValue}`, () => {
+          wrapper = setup();
+
+          wrapper.find(radio).trigger('click');
+
+          const updateTypeEmit = wrapper.emitted('update:type');
+
+          expect(updateTypeEmit).toHaveLength(1);
+          expect(updateTypeEmit[0]).toEqual([expectedValue]);
+        });
+      },
+    );
+
+    describe('when showType is set to false', () => {
+      it('shows types radios', () => {
+        wrapper = setup({ showTypes: false });
+
+        expect(
+          wrapper.findComponent(elements.generativeRadio).exists(),
+        ).toBeFalsy();
+
+        expect(
+          wrapper.findComponent(elements.classificationRadio).exists(),
+        ).toBeFalsy();
+      });
+    });
+  });
+});

--- a/src/components/intelligences/__tests__/IntelligencesFilter.unit.spec.js
+++ b/src/components/intelligences/__tests__/IntelligencesFilter.unit.spec.js
@@ -44,10 +44,6 @@ const setup = ({ category, loadingType, showTypes } = {}) =>
 describe('IntelligencesFilter.vue', () => {
   let wrapper;
 
-  it('', () => {
-    wrapper = setup();
-  });
-
   describe('when category is not set', () => {
     it('should not show the category select', () => {
       wrapper = setup({ category: undefined });

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -45,6 +45,8 @@
         <IntelligencesFilter
           v-model:name="filterIntelligenceName"
           v-model:type="fitlerIntelligenceType"
+          :loadingType="intelligencesNexusAI.firstLoading"
+          :showTypes="!isGenerativeAIListEmpty"
           class="filters"
         />
 
@@ -122,7 +124,7 @@
       maxWidth="750px"
       class="create-intelligence-modal"
     >
-      <CreateRepositoryForm @cancelCreation="openModal = false" />
+      <CreateRepositoryForm @cancel-creation="openModal = false" />
     </ModalNext>
   </div>
 </template>
@@ -187,6 +189,7 @@ export default {
 
       intelligencesNexusAI: {
         firstLoad: true,
+        firstLoading: true,
         orgUuid: this.$store.state.Auth.connectOrgUuid,
         data: [],
         next: null,
@@ -199,6 +202,13 @@ export default {
   },
 
   computed: {
+    isGenerativeAIListEmpty() {
+      return (
+        this.intelligencesNexusAI.status === 'complete' &&
+        this.intelligencesNexusAI.data.length === 0
+      );
+    },
+
     intelligences() {
       let items;
 
@@ -252,6 +262,16 @@ export default {
   },
 
   watch: {
+    isGenerativeAIListEmpty: {
+      handler() {
+        if (this.isGenerativeAIListEmpty) {
+          this.fitlerIntelligenceType = 'classification';
+        }
+      },
+
+      immediate: true,
+    },
+
     isShowingEndOfList() {
       if (this.isShowingEndOfList) {
         if (
@@ -388,6 +408,8 @@ export default {
           this.intelligencesNexusAI.status = 'complete';
         }
       } finally {
+        this.intelligencesNexusAI.firstLoading = false;
+
         if (this.intelligencesNexusAI.status === 'loading') {
           this.intelligencesNexusAI.status = null;
         }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To start the process of deprecating the content base, this was the first step, hiding the option of generative AIs for people who don't have any content base.

### Summary of Changes
<!--- Describe your changes in detail -->
* Hides the option of generative AIs for people who have no content base;
* Adds unit test for `IntelligencesFilter.vue`.
