### PR TITLE
[Nexus-1583] Content Base Files: Error Alert for Unsupported Files and Files That Exceed the Size Limit

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -177,7 +177,7 @@
     "files": {
       "upload_content": "Upload content from files",
       "drag_and_drop_your_file_here": "Drag and drop your file here to add the content to the AI knowledge base.",
-      "supported_files": "Supported formats: .pdf, .doc, docx, .txt, .xls and .xlsx.<br /> 250MB limit per file.",
+      "supported_files": "Supported formats: {suportedFormats}.<br /> {limitMB}MB limit per file.",
       "file_error": "File error. Delete and add again",
       "browse_file": "Add file",
       "uploaded_files": "Uploaded files",
@@ -188,6 +188,8 @@
       },
       "content_of_the_files_has_been_added": "The content of the files has been added to the base",
       "file_removed_from_base": "{name} removed from content base",
+      "unsupported_format": "The file format is not supported",
+      "exceeds_limit": "The file size exceeds the {limitMB}MB limit",
       "delete_file": {
         "title": "Delete file",
         "description": "Are you sure you want to delete the file <b>{name}</b>?<br />The contents of this file will be removed from the AI base",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -177,7 +177,7 @@
     "files": {
       "upload_content": "Cargar contenido a partir de archivos",
       "drag_and_drop_your_file_here": "Arrastre y suelte su archivo aquí para añadir el contenido a la base de conocimientos de IA.",
-      "supported_files": "Formatos admitidos: .pdf, .doc, docx, .txt, .xls y .xlsx.<br /> Límite de 250 MB por archivo.",
+      "supported_files": "Formatos admitidos: {suportedFormats}.<br /> Límite de {limitMB}MB por archivo.",
       "file_error": "Error de archivo. Eliminar y añadir de nuevo",
       "browse_file": "Añadir archivo",
       "uploaded_files": "Archivos cargados",
@@ -188,6 +188,8 @@
       },
       "content_of_the_files_has_been_added": "El contenido de los ficheros se ha añadido a la base",
       "file_removed_from_base": "{name} eliminada de la base de contenidos",
+      "unsupported_format": "El formato de archivo no es compatible",
+      "exceeds_limit": "El tamaño del archivo supera el límite de {limitMB}MB",
       "delete_file": {
         "title": "Eliminar archivo",
         "description": "¿Estás seguro de que quieres eliminar el archivo <b>{name}</b>?<br />El contenido de este archivo se eliminará de la base de datos de AI",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -177,7 +177,7 @@
     "files": {
       "upload_content": "Carregar conteúdo de arquivos",
       "drag_and_drop_your_file_here": "Arraste e solte seu arquivo aqui para adicionar o conteúdo à base de conhecimento da IA.",
-      "supported_files": "Formatos suportados: .pdf, .doc, docx, .txt, .xls e .xlsx.<br /> Limite de 250MB por arquivo.",
+      "supported_files": "Formatos suportados: {suportedFormats}.<br /> Limite de {limitMB}MB por arquivo.",
       "file_error": "Arquivo com erro. Exclua e adicione-o novamente.",
       "browse_file": "Adicionar arquivo",
       "uploaded_files": "Arquivos carregados",
@@ -188,6 +188,8 @@
       },
       "content_of_the_files_has_been_added": "O conteúdo dos arquivos foi adicionado à base",
       "file_removed_from_base": "{name} removido da base de conteúdo",
+      "unsupported_format": "O formato do arquivo não é suportado",
+      "exceeds_limit": "O tamanho do arquivo excede o limite de {limitMB}MB",
       "delete_file": {
         "title": "Excluir arquivo",
         "description": "Tem certeza que deseja excluir o arquivo <b>{name}</b>?<br />O conteúdo desse arquivo será removido da base da IA",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Visual feedback to the user when there is an error with the file format and size.

### Summary of Changes
<!--- Describe your changes in detail -->
* Adds verification of file format and size.

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
![image](https://github.com/user-attachments/assets/ed0e9706-10ad-4d93-b279-f4edd4de370a)
![image](https://github.com/user-attachments/assets/9f480184-7c6a-4132-a83c-a1826e70a8bb)
