### PR TITLE
[Nexus-1774] Bug: Send the Correct Auth Token to Keycloak User Info

### DIFF
--- a/src/utils/HotjarIdentifyUser.js
+++ b/src/utils/HotjarIdentifyUser.js
@@ -19,7 +19,7 @@ export function HotjarIdentifyUser({ token }) {
       `https://${keycloak.server}/auth/realms/${keycloak.realm}/protocol/openid-connect/userinfo`,
       {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: token,
         },
       },
     )

--- a/src/utils/__test__/HotjarIdentifyUser.unit.spec.js
+++ b/src/utils/__test__/HotjarIdentifyUser.unit.spec.js
@@ -60,7 +60,7 @@ describe('HotjarIdentifyUser.js', () => {
         KEYCLOAK_REALM: 'realm-2',
       };
 
-      HotjarIdentifyUser({ token: '1234' });
+      HotjarIdentifyUser({ token: 'Bearer 1234' });
     });
 
     it('calls keycloak get user info', () => {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes
<!--- Describe your changes in detail -->
* Sends the correct auth token to Keycloak user info.