### PR TITLE
[NEXUS-2065] - Disable actions by user perm

### DIFF
--- a/src/__tests__/components/actions/ModalChangeAction.spec.js
+++ b/src/__tests__/components/actions/ModalChangeAction.spec.js
@@ -82,6 +82,19 @@ global.runtimeVariables = {
 
 const pinia = createTestingPinia({ stubActions: false });
 
+const actionEditable = {
+  uuid: '1234',
+  name: 'Action Name',
+  description: 'Action Description',
+  group: 'custom',
+  editable: true,
+};
+
+const actionNonEditable = {
+  ...actionEditable,
+  editable: false,
+};
+
 describe('ModalChangeAction', () => {
   let wrapper;
 
@@ -89,12 +102,7 @@ describe('ModalChangeAction', () => {
     mount(ModalChangeAction, {
       props: {
         modelValue: true,
-        action: {
-          uuid: '1234',
-          name: 'Action Name',
-          description: 'Action Description',
-          group: 'custom',
-        },
+        action: actionEditable,
       },
 
       global: {
@@ -115,6 +123,20 @@ describe('ModalChangeAction', () => {
     expect(description.wrapperElement.querySelector('textarea').value).toBe(
       'Action Description',
     );
+  });
+
+  it('should disable name input and description textarea if the action is not editable', async () => {
+    wrapper = setup();
+
+    const name = wrapper.find('[data-test="name-input"]');
+    const description = wrapper.find('[data-test="description-textarea"]');
+
+    await wrapper.setProps({
+      action: actionNonEditable,
+    });
+
+    expect(name.attributes('disabled')).toBe('true');
+    expect(description.classes()).toContain('disabled');
   });
 
   it('displays the flow name', async () => {

--- a/src/api/nexus/Actions.js
+++ b/src/api/nexus/Actions.js
@@ -79,11 +79,21 @@ export const Actions = {
     const { data } = await request.$http.get(`api/${projectUuid}/flows/`);
 
     return data.map(
-      ({ uuid, name, prompt, action_type, content_base, fallback, group }) => ({
+      ({
+        uuid,
+        name,
+        prompt,
+        action_type,
+        editable,
+        content_base,
+        fallback,
+        group,
+      }) => ({
         uuid,
         name,
         prompt,
         type: action_type,
+        editable,
         group: Object.values(groups).includes(group) ? group : 'custom',
       }),
     );

--- a/src/components/Brain/ContentBase/ContentItem.vue
+++ b/src/components/Brain/ContentBase/ContentItem.vue
@@ -133,8 +133,9 @@ export default {
           this.file.status === 'uploaded',
 
         remove:
+          (this.extension === 'action' && this.file.editable) ||
           ['fail-upload', 'fail'].includes(this.file.status) ||
-          !this.file.uuid?.startsWith('temp-'),
+          (this.extension !== 'action' && !this.file.uuid?.startsWith('temp-')),
       };
 
       const actions = [];

--- a/src/components/Brain/ContentBase/__tests__/ContentItem.spec.js
+++ b/src/components/Brain/ContentBase/__tests__/ContentItem.spec.js
@@ -13,7 +13,11 @@ nexusaiAPI.intelligences.contentBases.files.download = vi
 
 function createFileObject(
   type,
-  { status = 'uploaded', created_at = '2024-01-01T00:00:00.000Z' } = {},
+  {
+    status = 'uploaded',
+    editable = true,
+    created_at = '2024-01-01T00:00:00.000Z',
+  } = {},
 ) {
   const now = new Date().toISOString();
 
@@ -25,6 +29,7 @@ function createFileObject(
       description: 'When the user wants to go to this action',
       created_at: now,
       status,
+      editable,
     },
     site: {
       uuid: '1234',
@@ -84,6 +89,7 @@ describe('ContentItem.vue', () => {
 
         global: {
           plugins: [store],
+          stubs: ['teleport'],
         },
       });
     });
@@ -99,6 +105,29 @@ describe('ContentItem.vue', () => {
         await wrapper.element.firstElementChild.click();
 
         expect(wrapper.emitted('click')).toHaveLength(1);
+      });
+    });
+
+    describe('when it is an action with editable boolean', () => {
+      const checkRemoveActionVisibility = async (editable, shouldExist) => {
+        await wrapper.setProps({
+          file: createFileObject('action', { editable }),
+        });
+
+        const removeAction = wrapper.find('[data-test="Remove action"]');
+        expect(removeAction.exists()).toBe(shouldExist);
+      };
+
+      describe('is false', () => {
+        it('does not show the remove action', async () => {
+          await checkRemoveActionVisibility(false, false);
+        });
+      });
+
+      describe('is true', () => {
+        it('shows the remove action', async () => {
+          await checkRemoveActionVisibility(true, true);
+        });
       });
     });
   });

--- a/src/components/actions/ModalChangeAction.vue
+++ b/src/components/actions/ModalChangeAction.vue
@@ -295,6 +295,14 @@ async function saveAction() {
   margin-top: $unnnic-spacing-sm;
 }
 
+.text-area :deep(textarea:disabled) {
+  outline-color: $unnnic-color-neutral-cleanest;
+  background-color: $unnnic-color-neutral-lightest;
+  color: $unnnic-color-neutral-cleanest;
+
+  cursor: not-allowed;
+}
+
 .flow-area {
   margin-top: $unnnic-spacing-md;
 

--- a/src/components/actions/ModalChangeAction.vue
+++ b/src/components/actions/ModalChangeAction.vue
@@ -42,6 +42,7 @@
               'modals.actions.add.steps.describe.inputs.description.placeholder',
             )
           "
+          :disabled="action.editable === false"
           data-test="description-textarea"
         />
       </UnnnicFormElement>
@@ -62,6 +63,7 @@
               'modals.actions.add.steps.nominate_action.inputs.name.placeholder',
             )
           "
+          :disabled="action.editable === false"
           data-test="name-input"
         />
       </UnnnicFormElement>

--- a/src/views/Brain/RouterActions.vue
+++ b/src/views/Brain/RouterActions.vue
@@ -22,6 +22,7 @@
         data: items.data.map((action) => ({
           ...action,
           extension_file: 'action',
+          editable: action.editable ?? true,
           created_file_name: action.name,
         })),
       }"
@@ -154,6 +155,7 @@ export default {
         uuid,
         type: action.type,
         name: action.name,
+        editable: action.editable,
         description: action.prompt,
         group: action.group,
         status: null,


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Some commerce users do not have permission to create and edit new actions in the agent builder.

### Summary of Changes
- Removed delete action button depends by action is editable and tests;