### PR TITLE
[NEXUS-2114] - Accept hyphen in content url domain

### DIFF
--- a/src/components/Brain/ContentBase/ModalAddSite.vue
+++ b/src/components/Brain/ContentBase/ModalAddSite.vue
@@ -67,7 +67,7 @@ const submitDisabled = computed(() => !validURL(site.value));
 
 function validURL(url) {
   // eslint-disable-next-line no-useless-escape
-  return /^[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/i.test(
+  return /^(http(s)?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/i.test(
     url.trim(),
   );
 }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When adding a content url, it was not identified as valid if there was a hyphen in the domain.

### Summary of Changes
- Replaced ModalAddSite regex at valid url function.
