### PR TITLE
[NEXUS-2151] - Defined orgs can create content AI

### DIFF
--- a/config.js.tmpl
+++ b/config.js.tmpl
@@ -30,6 +30,7 @@ const runtimeVariables = (() => ({
   KEYCLOAK_REALM: ('${KEYCLOAK_REALM}' || ''),
   HOTJAR_ID: ('${HOTJAR_ID}' || ''),
   TEMPLATE_LINK_FLOW_EDITOR: '${TEMPLATE_LINK_FLOW_EDITOR}',
+  VITE_ORGS_CAN_CREATE_CONTENT_AI: '${VITE_ORGS_CAN_CREATE_CONTENT_AI}',
   
   get(name){
     return this[name];

--- a/public/config.js
+++ b/public/config.js
@@ -28,8 +28,8 @@ const runtimeVariables = (() => ({
   VITE_LOGROCKET_PARENT_DOMAIN: 'https://dash-develop.weni.ai/',
   VITE_OPTIONS_WENIGPT:
     '[{"name": "shark-1", "description": "router.tunings.fields.shark-1", "model": "shark-1"}]',
-  SENTRY_ENVIRONMENT: 'develop',
-
+  SENTRY_ENVIRONMENT: 'staging',
+  VITE_ORGS_CAN_CREATE_CONTENT_AI: '',
   get(name) {
     return this[name];
   },

--- a/src/components/repository/CreateRepository/CreateIntelligenceModal.vue
+++ b/src/components/repository/CreateRepository/CreateIntelligenceModal.vue
@@ -127,7 +127,7 @@ export default {
       return runtimeVariables
         .get('VITE_ORGS_CAN_CREATE_CONTENT_AI')
         ?.split(', ')
-        .includes(this.getOrgSelected);
+        .includes(this.$store.state.Auth.connectOrgUuid);
     },
 
     disabledSubmit() {
@@ -164,7 +164,7 @@ export default {
       try {
         if (this.data.repository_type === 'content') {
           const response = await nexusaiAPI.createIntelligence({
-            orgUuid: this.getOrgSelected,
+            orgUuid: this.$store.state.Auth.connectOrgUuid,
             name: this.data.name,
             description: this.data.description,
           });

--- a/src/components/repository/CreateRepository/CreateIntelligenceModal.vue
+++ b/src/components/repository/CreateRepository/CreateIntelligenceModal.vue
@@ -134,7 +134,7 @@ export default {
       const { data } = this;
 
       return (
-        !this.isOrgCanCreateContentAI ||
+        (!this.isOrgCanCreateContentAI && data.repository_type === 'content') ||
         !data.name ||
         !data.description ||
         !data.repository_type ||

--- a/src/components/repository/CreateRepository/CreateIntelligenceModal.vue
+++ b/src/components/repository/CreateRepository/CreateIntelligenceModal.vue
@@ -127,13 +127,14 @@ export default {
       return runtimeVariables
         .get('VITE_ORGS_CAN_CREATE_CONTENT_AI')
         ?.split(', ')
-        .includes(this.$store.state.Auth.connectOrgUuid);
+        .includes(this.getOrgSelected);
     },
 
     disabledSubmit() {
       const { data } = this;
 
       return (
+        !this.isOrgCanCreateContentAI ||
         !data.name ||
         !data.description ||
         !data.repository_type ||

--- a/src/components/repository/CreateRepository/CreateIntelligenceModal.vue
+++ b/src/components/repository/CreateRepository/CreateIntelligenceModal.vue
@@ -35,7 +35,7 @@
       />
 
       <section
-        v-if="data.repository_type === 'content'"
+        v-if="!isOrgCanCreateContentAI && data.repository_type === 'content'"
         class="brain-use-warning"
       >
         <UnnnicIcon
@@ -117,6 +117,13 @@ export default {
       return Object.keys(defaultData).some(
         (attr) => get(defaultData, attr) !== get(this.data, attr),
       );
+    },
+
+    isOrgCanCreateContentAI() {
+      return runtimeVariables
+        .get('VITE_ORGS_CAN_CREATE_CONTENT_AI')
+        ?.split(', ')
+        .includes(this.$store.state.Auth.connectOrgUuid);
     },
 
     disabledSubmit() {

--- a/src/store/auth/state.js
+++ b/src/store/auth/state.js
@@ -2,6 +2,6 @@ export default {
   token: null,
   org: null,
   project: null,
-  connectOrgUuid: null,
+  connectOrgUuid: sessionStorage.getItem('orgUuid') || null,
   connectProjectUuid: sessionStorage.getItem('projectUuid') || null,
 };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Some orgs needed access to content creation AIs.

### Summary of Changes
- Enable content AI creation for specific orgs;
- Added `VITE_ORGS_CAN_CREATE_CONTENT_AI` var env.