### PR TITLE
[NEXUS-2160] - Fix spaces at content URLs

### DIFF
--- a/src/components/Brain/ContentBase/ModalAddSite.vue
+++ b/src/components/Brain/ContentBase/ModalAddSite.vue
@@ -38,6 +38,7 @@
           :placeholder="
             $t('content_bases.sites.sidebar_add.fields.link.placeholder')
           "
+          @input="onInput"
         ></UnnnicInput>
       </UnnnicFormElement>
     </section>
@@ -62,6 +63,11 @@ const props = defineProps({
 });
 
 const site = ref('');
+
+const onInput = (event) => {
+  const siteWithoutSpaces = event.target.value.trim().split(/\s+/).join('');
+  site.value = siteWithoutSpaces;
+};
 
 const submitDisabled = computed(() => !validURL(site.value));
 

--- a/src/components/Brain/ContentBase/__tests__/ModalAddSite.spec.js
+++ b/src/components/Brain/ContentBase/__tests__/ModalAddSite.spec.js
@@ -54,6 +54,15 @@ describe('ModalAddSite', () => {
       await input.setValue('invalid-url');
       expect(wrapper.vm.submitDisabled).toBe(true);
     });
+
+    it('should replace spaces on input site', async () => {
+      const input = wrapper.findComponent('[data-test="site-input"]');
+
+      await input.setValue(' www . valid - url . com ');
+      wrapper.vm.onInput({ target: { value: ' www . valid - url . com ' } });
+
+      expect(wrapper.vm.site).toBe('www.valid-url.com');
+    });
   });
 
   describe('when the user enters a valid URL', () => {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When users added content URLs with spaces at the beginning or end, the validator did not identify this as an invalid URL and requested it as such, generating an error in the request.

### Summary of Changes
A function that removes all spaces from the URL in ModalAddSite, triggered by the input event, has been added.
A test for this functionality has also been added.
