### PR TITLE
[NEXUS-2161] - Multiple actions per flow

### DIFF
--- a/src/api/nexus/Actions.js
+++ b/src/api/nexus/Actions.js
@@ -89,6 +89,7 @@ export const Actions = {
         content_base,
         fallback,
         group,
+        flow_uuid,
       }) => ({
         uuid,
         name,
@@ -96,6 +97,7 @@ export const Actions = {
         type: action_type,
         editable,
         group: Object.values(groups).includes(group) ? group : 'custom',
+        flow_uuid,
       }),
     );
   },

--- a/src/api/nexus/Actions.js
+++ b/src/api/nexus/Actions.js
@@ -49,6 +49,7 @@ export const Actions = {
       name: data.name,
       prompt: data.prompt,
       type: data.action_type,
+      flow_uuid: data.flow_uuid,
       group:
         templateUuid && Object.values(groups).includes(data.group)
           ? data.group

--- a/src/components/actions/steps/SelectFlow.vue
+++ b/src/components/actions/steps/SelectFlow.vue
@@ -71,11 +71,13 @@
         :text="getTreatedTooltipFlowActions(item)"
         enabled
         class="flow-item__actions"
+        data-test="flow-item-actions-tooltip"
       >
         <UnnnicIcon
           icon="bolt"
           size="sm"
           scheme="neutral-clean"
+          data-test="flow-item-actions-icon"
         />
         {{ item.actions.length }}
       </UnnnicToolTip>

--- a/src/components/actions/steps/SelectFlow.vue
+++ b/src/components/actions/steps/SelectFlow.vue
@@ -49,11 +49,7 @@
       v-for="(item, index) in itemsData"
       :key="index"
       side="top"
-      :text="
-        isFlowAlreadyAdded(item)
-          ? $t('modals.actions.add.steps.select_flow.flow_already_in_use')
-          : item.name
-      "
+      :text="item.name"
       enabled
     >
       <section
@@ -61,7 +57,6 @@
           'flow-item',
           {
             'flow-item--selected': isFlowSelected(item),
-            'flow-item--disabled': isFlowDisabled(item),
           },
         ]"
         :data-test="`flow-${item.uuid}`"
@@ -187,19 +182,7 @@ function isFlowSelected(flow) {
   return props.flowUuid === flow.uuid;
 }
 
-function isFlowAlreadyAdded(flow) {
-  return actionsStore.actions.data.some(({ uuid }) => flow.uuid === uuid);
-}
-
-function isFlowDisabled(flow) {
-  return isFlowAlreadyAdded(flow);
-}
-
 function selectFlow(flow) {
-  if (isFlowDisabled(flow)) {
-    return;
-  }
-
   emit('update:flowUuid', flow.uuid);
   emit('update:name', flow.name);
 }
@@ -281,26 +264,9 @@ function selectFlow(flow) {
     color: $unnnic-color-weni-600;
   }
 
-  &:hover:not(&--disabled) {
-    border: $unnnic-border-width-thinner solid $unnnic-color-weni-500;
-    background: rgba(0, 222, 210, 0.16);
-  }
-
   &--selected {
     border: $unnnic-border-width-thinner solid $unnnic-color-weni-500;
     background: rgba(0, 222, 210, 0.16);
-  }
-
-  &--disabled {
-    user-select: none;
-    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-    background-color: $unnnic-color-neutral-soft;
-    cursor: not-allowed;
-  }
-
-  &--disabled,
-  &--disabled &__icon {
-    color: $unnnic-color-neutral-clean;
   }
 }
 </style>

--- a/src/components/actions/steps/__tests__/SelectFlow.unit.spec.js
+++ b/src/components/actions/steps/__tests__/SelectFlow.unit.spec.js
@@ -1,10 +1,11 @@
 import { mount } from '@vue/test-utils';
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import SelectFlow from '../SelectFlow.vue';
 import lodash from 'lodash';
 import { createPinia, setActivePinia } from 'pinia';
 import { Actions } from '@/api/nexus/Actions';
 import { useActionsStore } from '@/store/Actions';
+import i18n from '@/utils/plugins/i18n';
 
 vi.spyOn(lodash, 'debounce').mockImplementation((fn) => fn);
 
@@ -41,10 +42,11 @@ const items = {
 };
 
 const alreadyAddedAction = {
-  uuid: '123',
+  uuid: '12345',
   name: 'Action One',
   prompt: 'Action One Description',
   type: 'custom',
+  flow_uuid: '123',
 };
 
 describe('SelectFlow.vue', () => {
@@ -115,26 +117,39 @@ describe('SelectFlow.vue', () => {
 
       selectableFlow.trigger('click');
 
-      expect(wrapper.emitted('update:flowUuid')).toContainEqual(['456']);
-      expect(wrapper.emitted('update:name')).toContainEqual(['Flow Two']);
+      expect(wrapper.emitted('update:flowUuid')).toContainEqual(['123']);
+      expect(wrapper.emitted('update:name')).toContainEqual(['Flow One']);
     });
   });
 
-  describe('when the user wants to select an already added flow', () => {
-    it('should not emit update:flowUuid and update:name', async () => {
+  describe('when the flow has more than one action selected', () => {
+    it('should render actions length, icon, and tooltip with actions names', async () => {
       vi.spyOn(Actions, 'list').mockResolvedValue([alreadyAddedAction]);
-
       const actionsStore = useActionsStore();
       await actionsStore.load();
 
-      const nonSelectableFlow = flows.find((flow) => {
-        return flow.attributes('data-test').endsWith(alreadyAddedAction.uuid);
-      });
+      const actionIcon = wrapper.findComponent(
+        '[data-test="flow-item-actions-icon"]',
+      );
+      expect(actionIcon.exists()).toBe(true);
+      expect(actionIcon.props('icon')).toBe('bolt');
 
-      nonSelectableFlow.trigger('click');
+      const tooltip = wrapper.findComponent(
+        '[data-test="flow-item-actions-tooltip"]',
+      );
+      expect(tooltip.exists()).toBe(true);
+      expect(tooltip.text()).toContain('1');
 
-      expect(wrapper.emitted()).not.toHaveProperty('update:flowUuid');
-      expect(wrapper.emitted()).not.toHaveProperty('update:name');
+      const formattedActions = i18n.global.t(
+        'modals.actions.add.steps.select_flow.flow_assigned_actions',
+        1,
+        {
+          count: 1,
+          actions: 'Action One',
+        },
+      );
+
+      expect(tooltip.props('text')).toBe(formattedActions);
     });
   });
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1543,7 +1543,7 @@
                 "placeholder": "Search flow"
               }
             },
-            "flow_already_in_use": "This flow is already linked to an action"
+            "flow_assigned_actions": "This flow has already been assigned to {count} action:\n{actions} | This flow has already been assigned to {count} actions:\n{actions}"
           },
           "nominate_action": {
             "title": "Name action",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1522,7 +1522,7 @@
                 "placeholder": "Buscar flujos"
               }
             },
-            "flow_already_in_use": "Este flujo ya está vinculado a una acción"
+            "flow_assigned_actions": "Este flujo ya ha sido asignado a {count} acción::\n{actions} | Este flujo ya se ha asignado a {count} acciones:\n{actions}"
           },
           "nominate_action": {
             "title": "Nombre acción",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1522,7 +1522,7 @@
                 "placeholder": "Buscar flujos"
               }
             },
-            "flow_assigned_actions": "Este flujo ya ha sido asignado a {count} acción::\n{actions} | Este flujo ya se ha asignado a {count} acciones:\n{actions}"
+            "flow_assigned_actions": "Este flujo ya ha sido asignado a {count} acción:\n{actions} | Este flujo ya se ha asignado a {count} acciones:\n{actions}"
           },
           "nominate_action": {
             "title": "Nombre acción",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1501,7 +1501,7 @@
                 "placeholder": "Pesquisar fluxo"
               }
             },
-            "flow_already_in_use": "Esse fluxo já está vinculado à uma ação"
+            "flow_assigned_actions": "Esse fluxo já foi atribuído para {count} ação:\n{actions} | Esse fluxo já foi atribuído para {count} ações:\n{actions}"
           },
           "nominate_action": {
             "title": "Nomear ação",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Summary of Changes
- Removed blocking of only one stream per action;
- Added tooltip and count of actions by flow;
- Added tests to SelectFlow actions count and tooltip;

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Modal select action flow](https://www.figma.com/design/5E67hPt0HlCDckwCtnn1HR/Brain-Vision?node-id=466-4744&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/110b86df-9470-4462-92ce-8339fac06616)
