### PR TITLE
[NEXUS-2227] - Fix "Flow name unavailable" with multiple flows per action

### DIFF
--- a/src/views/Brain/RouterActions.vue
+++ b/src/views/Brain/RouterActions.vue
@@ -152,7 +152,7 @@ export default {
       const action = this.items.data.find((action) => action.uuid === uuid);
 
       this.currentActionEditing = {
-        uuid,
+        uuid: action.flow_uuid,
         type: action.type,
         name: action.name,
         editable: action.editable,


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When editing an action, the flow name was not recognized due to a change in the object returned by the request.

### Summary of Changes
Changed key in RoutecActions so that action editing recognizes the right uuid of the flow and gets its name.

## Demonstration
Bug before this fix:
![image](https://github.com/user-attachments/assets/01dd326f-d2b6-4877-b718-91ae97ec5b34)

