### PR TITLE
[NEXUS-2230] - Hotfix ModalChangeAction save

### DIFF
--- a/src/__tests__/components/actions/ModalChangeAction.spec.js
+++ b/src/__tests__/components/actions/ModalChangeAction.spec.js
@@ -83,7 +83,8 @@ global.runtimeVariables = {
 const pinia = createTestingPinia({ stubActions: false });
 
 const actionEditable = {
-  uuid: '1234',
+  uuid: 'abcd',
+  flow_uuid: '1234',
   name: 'Action Name',
   description: 'Action Description',
   group: 'custom',
@@ -214,7 +215,7 @@ describe('ModalChangeAction', () => {
           projectUuid: 'test2323test',
           name: 'Action Name Edited',
           prompt: 'Action Description Edited',
-          actionUuid: '1234',
+          actionUuid: 'abcd',
         }),
       );
     });

--- a/src/components/actions/ModalChangeAction.vue
+++ b/src/components/actions/ModalChangeAction.vue
@@ -185,7 +185,7 @@ onBeforeMount(() => {
   name.value = action.name;
   description.value = action.description;
 
-  searchForFlowUuid(action.uuid);
+  searchForFlowUuid(action.flow_uuid);
 });
 
 function close() {
@@ -235,7 +235,7 @@ function openFlowEditor() {
 
   const transformedLink = templateLinkFlowEditor
     .replace('{dashProjectUuid}', store.state.Auth.connectProjectUuid)
-    .replace('{flowUuid}', props.action.uuid);
+    .replace('{flowUuid}', props.action.flow_uuid);
 
   window.open(transformedLink);
 }

--- a/src/views/Brain/RouterActions.vue
+++ b/src/views/Brain/RouterActions.vue
@@ -152,7 +152,8 @@ export default {
       const action = this.items.data.find((action) => action.uuid === uuid);
 
       this.currentActionEditing = {
-        uuid: action.flow_uuid,
+        uuid: action.uuid,
+        flow_uuid: action.flow_uuid,
         type: action.type,
         name: action.name,
         editable: action.editable,


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users are unable to edit an action due to the wrong uuid that the application is passing to the api.

### Summary of Changes
Adjusted uuid passed to the api when trying to save an action.