### PR TITLE
[NEXUS-2320] - Monitoring inspect sources tooltip

### DIFF
--- a/src/components/Brain/Monitoring/ResponseSuccessGroundedness/TextSentences.vue
+++ b/src/components/Brain/Monitoring/ResponseSuccessGroundedness/TextSentences.vue
@@ -46,12 +46,16 @@ function clearHoveredSentence() {
   hoveredSentence.value = null;
 }
 
-function truncateString(str, maxLength = 25) {
-  return str.length > maxLength ? `${str.slice(0, maxLength)}...` : str;
+function truncateString(string, maxLength = 25) {
+  if (!string) return;
+
+  return string.length > maxLength
+    ? `${string.slice(0, maxLength)}...`
+    : string;
 }
 
 function getTooltipText(fragment) {
-  const truncatedFileName = truncateString(fragment.sources[0].filename);
+  const truncatedFileName = truncateString(fragment.sources?.[0].filename);
   const confidence = i18n.global.t(
     'router.monitoring.inspect_response.confidence_percentage',
     {

--- a/src/components/Brain/Monitoring/ResponseSuccessGroundedness/TextSentences.vue
+++ b/src/components/Brain/Monitoring/ResponseSuccessGroundedness/TextSentences.vue
@@ -2,26 +2,30 @@
   <section
     data-testid="sentences"
     class="text-sentences"
+    @mouseleave="clearHoveredSentence"
   >
-    <template
-      v-for="fragment in fragments"
+    <UnnnicToolTip
+      v-for="(fragment, index) in fragments"
       :key="fragment.sentence"
+      data-testid="sentence-text"
+      :text="getTooltipText(fragment)"
+      :class="getTextClasses(index, fragment)"
+      side="top"
+      enabled
+      :forceOpen="hoveredSentence === index"
+      @mouseover="setHoveredSentence(index)"
     >
-      <p
-        data-testid="sentence-text"
-        :class="[
-          'text-sentences__text',
-          `text-sentences__text--${getReliabilityLevel(fragment)}`,
-        ]"
-      >
-        {{ fragment.sentence }}
-      </p>
-    </template>
+      {{ fragment.sentence }}
+    </UnnnicToolTip>
   </section>
 </template>
 
 <script setup>
-defineProps({
+import { ref } from 'vue';
+
+import i18n from '@/utils/plugins/i18n';
+
+const props = defineProps({
   fragments: {
     type: Array,
     required: true,
@@ -31,6 +35,39 @@ defineProps({
     required: true,
   },
 });
+
+const hoveredSentence = ref(null);
+
+function setHoveredSentence(index) {
+  hoveredSentence.value = index;
+}
+
+function clearHoveredSentence() {
+  hoveredSentence.value = null;
+}
+
+function truncateString(str, maxLength = 25) {
+  return str.length > maxLength ? `${str.slice(0, maxLength)}...` : str;
+}
+
+function getTooltipText(fragment) {
+  const truncatedFileName = truncateString(fragment.sources[0].filename);
+  const confidence = i18n.global.t(
+    'router.monitoring.inspect_response.confidence_percentage',
+    {
+      percentage: fragment.score,
+    },
+  );
+  return `${truncatedFileName}\n(${confidence})`;
+}
+
+function getTextClasses(index, fragment) {
+  return [
+    'text-sentences__text',
+    `text-sentences__text--${props.getReliabilityLevel(fragment)}`,
+    { 'text-sentences__text--focused': hoveredSentence.value === index },
+  ];
+}
 </script>
 
 <style scoped lang="scss">
@@ -47,6 +84,12 @@ defineProps({
     text-decoration-color: $unnnic-color-neutral-cleanest;
     text-decoration-thickness: 3px;
     text-underline-offset: 4px;
+
+    cursor: default;
+
+    &--focused {
+      text-decoration-thickness: 5px;
+    }
 
     &--slightly-reliable {
       text-decoration-color: $unnnic-color-weni-300;

--- a/src/components/Brain/Monitoring/ResponseSuccessGroundedness/__tests__/__snapshots__/TextSentences.spec.js.snap
+++ b/src/components/Brain/Monitoring/ResponseSuccessGroundedness/__tests__/__snapshots__/TextSentences.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`TextSentences.vue > matches the snapshot 1`] = `
 "<section data-v-44bdc72e="" data-testid="sentences" class="text-sentences">
-  <p data-v-44bdc72e="" data-testid="sentence-text" class="text-sentences__text text-sentences__text--slightly-reliable">This is slightly reliable.</p>
-  <p data-v-44bdc72e="" data-testid="sentence-text" class="text-sentences__text text-sentences__text--moderately-reliable">This is moderately reliable.</p>
-  <p data-v-44bdc72e="" data-testid="sentence-text" class="text-sentences__text text-sentences__text--highly-reliable">This is highly reliable.</p>
+  <div data-v-5b8c172b="" data-v-44bdc72e="" class="unnnic-tooltip text-sentences__text text-sentences__text--slightly-reliable" data-testid="sentence-text">This is slightly reliable.<span data-v-5b8c172b="" class="unnnic-tooltip-label unnnic-tooltip-label-top" data-testid="tooltip-label" style="left: 0px; top: -8px;">Test filename <br data-v-5b8c172b="">(0% confidence) <br data-v-5b8c172b=""><!----></span></div>
+  <div data-v-5b8c172b="" data-v-44bdc72e="" class="unnnic-tooltip text-sentences__text text-sentences__text--moderately-reliable" data-testid="sentence-text">This is moderately reliable.<span data-v-5b8c172b="" class="unnnic-tooltip-label unnnic-tooltip-label-top" data-testid="tooltip-label" style="left: 0px; top: -8px;">Test filename <br data-v-5b8c172b="">(0% confidence) <br data-v-5b8c172b=""><!----></span></div>
+  <div data-v-5b8c172b="" data-v-44bdc72e="" class="unnnic-tooltip text-sentences__text text-sentences__text--highly-reliable" data-testid="sentence-text">This is highly reliable.<span data-v-5b8c172b="" class="unnnic-tooltip-label unnnic-tooltip-label-top" data-testid="tooltip-label" style="left: 0px; top: -8px;">Test filename <br data-v-5b8c172b="">(0% confidence) <br data-v-5b8c172b=""><!----></span></div>
 </section>"
 `;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Improve the visualization of details for each sentence of the monitored response.

### Summary of Changes
- Added tooltip in each monitored sentence with source name and response reliability;
- Added increased outline-thickness when hovering over the sentence.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/5E67hPt0HlCDckwCtnn1HR/Brain-Vision?node-id=1590-7112&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/8b4873cb-d234-4428-a490-09af066c616b)
