### PR TITLE
[NEXUS-2317] - Fix monitoring websocket connect every mount

### DIFF
--- a/src/store/Monitoring.js
+++ b/src/store/Monitoring.js
@@ -72,6 +72,8 @@ export const useMonitoringStore = defineStore('monitoring', () => {
     inspectedAnswer: {},
   });
 
+  const ws = reactive(null);
+
   async function loadMessages({ page, pageInterval, tag, text }) {
     const { started_day, ended_day } = route.query;
     const currentNewMessages = [...messages.newMessages];
@@ -196,6 +198,7 @@ export const useMonitoringStore = defineStore('monitoring', () => {
 
   return {
     messages,
+    ws,
     loadMessages,
     loadMessageContext,
     loadMessageDetails,

--- a/src/views/Brain/RouterMonitoring/index.vue
+++ b/src/views/Brain/RouterMonitoring/index.vue
@@ -17,6 +17,7 @@ import WS from '@/websocket/setup';
 
 import { computed, onMounted, ref } from 'vue';
 import { useStore } from 'vuex';
+import { useMonitoringStore } from '@/store/Monitoring';
 
 import RouterMonitoringPerformance from './RouterMonitoringPerformance.vue';
 import RouterMonitoringReceivedMessages from './RouterMonitoringReceivedMessages.vue';
@@ -24,14 +25,21 @@ import RouterMonitoringReceivedMessages from './RouterMonitoringReceivedMessages
 const ws = ref(null);
 const store = useStore();
 const auth = computed(() => store.state.Auth);
+const monitoringStore = useMonitoringStore();
 
-onMounted(() => {
+function connectMonitoringWS() {
+  if (monitoringStore.ws) return;
+
   ws.value = new WS({
     project: auth.value.connectProjectUuid,
     token: auth.value.token.replace('Bearer ', ''),
   });
   ws.value.connect();
-});
+
+  monitoringStore.ws = ws;
+}
+
+onMounted(() => connectMonitoringWS());
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
A new Websocket connection was made each time the monitoring view was mounted, but the expected behavior is that there is only one connection.

### Summary of Changes
Added variable in the monitoring store for the ws instance and added a validation to only connect to the websocket if that instance does not exist. Also added tests for this behavior.
