### PR TITLE
[NEXUS-2395] - Fix order of action type at action create

### DIFF
--- a/src/components/actions/steps/SelectActionType.vue
+++ b/src/components/actions/steps/SelectActionType.vue
@@ -12,6 +12,7 @@
         :modelValue="actionTypeModelValue"
         :options="types"
         class="action-selector"
+        orderedByIndex
         @update:model-value="updateModel"
       />
     </UnnnicFormElement>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
To improve the UX at action create, was reordered the standard selected type to first position of the list.

### Summary of Changes
- Added `orderedByIndex` to select action type input.
