### PR TITLE
[NEXUS-2397] - Fix Bedrock not found content detail message

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -316,6 +316,9 @@
         "not_found": {
           "title": "The contents of the file could not be viewed",
           "description": "The contents of the file could not be found.<br />Please delete the file and try adding it again."
+        },
+        "bedrock": {
+          "title": "Content view is not available"
         }
       }
     },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -316,6 +316,9 @@
         "not_found": {
           "title": "No se ha podido visualizar el contenido del fichero",
           "description": "No se ha encontrado el contenido del archivo.<br />Por favor, elimine el archivo e intente añadirlo de nuevo."
+        },
+        "bedrock": {
+          "title": "La visualización de contenido no está disponible"
         }
       }
     },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -316,6 +316,9 @@
         "not_found": {
           "title": "Não foi possível visualizar o conteúdo do arquivo",
           "description": "Não foi possível localizar o conteúdo do arquivo.<br />Por favor, exclua o arquivo e tente adicioná-lo novamente."
+        },
+        "bedrock": {
+          "title": "A visualização de conteúdo não está disponível"
         }
       }
     },

--- a/src/views/Brain/Brain.vue
+++ b/src/views/Brain/Brain.vue
@@ -211,6 +211,10 @@ export default {
       });
 
       routerTunings.value.brainOn = data.brain_on;
+      store.commit('updateTuning', {
+        name: 'indexer_database',
+        value: data.indexer_database,
+      });
     };
 
     const loadContentBase = async () => {

--- a/src/views/ContentBases/components/FilePreviewNotFound.vue
+++ b/src/views/ContentBases/components/FilePreviewNotFound.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="not-found">
     <UnnnicIcon
-      icon="warning"
+      :icon="isProjectUsingBedrock ? 'info' : 'warning'"
       size="avatar-sm"
       scheme="neutral-cleanest"
     />
@@ -13,10 +13,11 @@
       weight="bold"
       marginTop="xs"
     >
-      {{ $t('content_bases.files.preview.not_found.title') }}
+      {{ title }}
     </UnnnicIntelligenceText>
 
     <UnnnicIntelligenceText
+      v-if="!isProjectUsingBedrock"
       color="neutral-cloudy"
       family="secondary"
       size="body-gt"
@@ -26,6 +27,25 @@
     </UnnnicIntelligenceText>
   </section>
 </template>
+
+<script setup>
+import { computed } from 'vue';
+import { useStore } from 'vuex';
+
+import i18n from '@/utils/plugins/i18n';
+
+const store = useStore();
+
+const isProjectUsingBedrock = computed(
+  () => store.state.Brain.tunings.indexer_database?.toLowerCase() === 'bedrock',
+);
+
+const title = computed(() =>
+  isProjectUsingBedrock.value
+    ? i18n.global.t('content_bases.files.preview.bedrock.title')
+    : i18n.global.t('content_bases.files.preview.not_found.title'),
+);
+</script>
 
 <style lang="scss" scoped>
 .not-found {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Files added to projects that use Bedrock do not have their content available through the backend, so it was necessary to change the informational message for this case.

### Summary of Changes
Changed the icon and description of the newsletter when the project's `indexer_database` is equal to `bedrock`

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/61c7b51b-b184-4046-a5b0-d10b4c62d630)