### PR TITLE
[NEXUS-2428] - Adjusted add instruction button only if last instruction has value

### DIFF
--- a/src/views/Brain/RouterCustomization.vue
+++ b/src/views/Brain/RouterCustomization.vue
@@ -126,7 +126,7 @@
             />
             <UnnnicButtonIcon
               v-bind="$props"
-              icon="delete-1-1"
+              icon="delete"
               :data-test="`btn-delete-inst-${index}`"
               class="btn-color"
               size="small"
@@ -145,7 +145,7 @@
         :text="$t('customization.instructions.add_instruction_btn')"
         type="tertiary"
         iconLeft="add-1"
-        :disabled="false"
+        :disabled="brain.instructions.current.at(-1)?.instruction === ''"
         @click="addEmptyInstruction"
       />
     </div>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
Users could add infinite empty instructions, so to improve the UI the rule for adding a new instruction was changed.

### Summary of Changes
- Changed the icon for deleting instructions to follow the pattern of the rest of the application.
- Added a rule to disable the button for adding a new instruction if the last one is empty.
