### PR TITLE
[NEXUS-2554] - Fix of profile personality field value

### DIFF
--- a/src/__tests__/integration/brain.integration.test.js
+++ b/src/__tests__/integration/brain.integration.test.js
@@ -311,6 +311,9 @@ describe('Brain integration', () => {
           RouterProfile,
           Tests,
         },
+        stubs: {
+          UnnnicSelectSmart: true,
+        },
       },
     });
 

--- a/src/views/Brain/RouterProfile/RouterProfileGeneralInfo.vue
+++ b/src/views/Brain/RouterProfile/RouterProfileGeneralInfo.vue
@@ -125,10 +125,6 @@ export default {
     personalities() {
       return [
         {
-          label: this.$t('profile.fields.personality'),
-          value: '',
-        },
-        {
           label: this.$t('profile.fields.personalities.friendly'),
           value: 'Amigável',
         },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
At old projects, the profile personality field is calling a nonexistent translation, like the demonstration.

### Summary of Changes
- Removed nonexistent placeholder in the profile personality field.

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/84331c63-7372-473e-aae7-ec3d17141eb3)