### PR TITLE
[NEXUS-2605] Removed preview outside agents team tab

### DIFF
--- a/src/components/Brain/BrainHeader.vue
+++ b/src/components/Brain/BrainHeader.vue
@@ -39,6 +39,7 @@
       type="primary"
       iconLeft="play_arrow"
       iconsFilled
+      :disabled="!agentsTeamStore.activeTeam.data.agents.length"
       @click="handlePreview"
     >
       {{ $t('router.agents_team.preview') }}
@@ -67,9 +68,11 @@ import { format, subDays } from 'date-fns';
 import useBrainRoutes from '@/composables/useBrainRoutes';
 import { useProfileStore } from '@/store/Profile';
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
-
+import { useAgentsTeamStore } from '@/store/AgentsTeam';
 import MonitoringViewFilter from './Monitoring/ViewFilter.vue';
 import PreviewDrawer from './Preview/PreviewDrawer.vue';
+
+const agentsTeamStore = useAgentsTeamStore();
 
 const brainRoutes = useBrainRoutes();
 const dateFilter = ref({

--- a/src/components/Brain/BrainHeader.vue
+++ b/src/components/Brain/BrainHeader.vue
@@ -39,7 +39,6 @@
       type="primary"
       iconLeft="play_arrow"
       iconsFilled
-      :disabled="!agentsTeamStore.activeTeam.data.agents.length"
       @click="handlePreview"
     >
       {{ $t('router.agents_team.preview') }}
@@ -68,11 +67,8 @@ import { format, subDays } from 'date-fns';
 import useBrainRoutes from '@/composables/useBrainRoutes';
 import { useProfileStore } from '@/store/Profile';
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
-import { useAgentsTeamStore } from '@/store/AgentsTeam';
 import MonitoringViewFilter from './Monitoring/ViewFilter.vue';
 import PreviewDrawer from './Preview/PreviewDrawer.vue';
-
-const agentsTeamStore = useAgentsTeamStore();
 
 const brainRoutes = useBrainRoutes();
 const dateFilter = ref({

--- a/src/views/Brain/Brain.vue
+++ b/src/views/Brain/Brain.vue
@@ -94,6 +94,7 @@ import i18n from '@/utils/plugins/i18n';
 import useBrainRoutes from '@/composables/useBrainRoutes';
 import BrainWarningBar from '@/components/Brain/BrainWarningBar.vue';
 import BrainHeaderPreview from '@/components/Brain/BrainHeaderPreview.vue';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 export default {
   name: 'Brain',
@@ -162,6 +163,7 @@ export default {
     const brainRoutes = useBrainRoutes();
     const showPreview = computed(
       () =>
+        !useFeatureFlagsStore().flags.agentsTeam &&
         brainRoutes.value.find((mappedRoute) => mappedRoute.page === route.name)
           ?.preview,
     );


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Until the design for the preview on other screens besides the agents team, for better user experience it was required to remove the preview from the other tabs

### Summary of Changes
- Removed preview of tabs that are not agents team.
