### PR TITLE
[NEXUS-2682] - New agents team view

### DIFF
--- a/src/__tests__/views/Brain/RouterAgentsTeam/ActiveTeam.spec.js
+++ b/src/__tests__/views/Brain/RouterAgentsTeam/ActiveTeam.spec.js
@@ -47,14 +47,6 @@ describe('ActiveTeam component', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('renders the title', () => {
-    const title = wrapper.find('[data-testid="title"]');
-    expect(title.exists()).toBe(true);
-    expect(title.text()).toBe(
-      i18n.global.t('router.agents_team.active_team.title'),
-    );
-  });
-
   // TODO: Fix this test
 
   // it('renders the loading state', async () => {

--- a/src/__tests__/views/Brain/RouterAgentsTeam/RouterAgentsTeam.spec.js
+++ b/src/__tests__/views/Brain/RouterAgentsTeam/RouterAgentsTeam.spec.js
@@ -2,7 +2,6 @@ import { shallowMount } from '@vue/test-utils';
 
 import RouterAgentsTeam from '@/views/Brain/RouterAgentsTeam/index.vue';
 import ActiveTeam from '@/views/Brain/RouterAgentsTeam/ActiveTeam.vue';
-import AgentsGallery from '@/views/Brain/RouterAgentsTeam/AgentsGallery.vue';
 import UnnnicDivider from '@/components/Divider.vue';
 
 describe('RouterAgentsTeam', () => {
@@ -17,8 +16,7 @@ describe('RouterAgentsTeam', () => {
   });
 
   it('renders the all components', () => {
-    expect(wrapper.findComponent(ActiveTeam).exists()).toBe(true);
     expect(wrapper.findComponent(UnnnicDivider).exists()).toBe(true);
-    expect(wrapper.findComponent(AgentsGallery).exists()).toBe(true);
+    expect(wrapper.findComponent(ActiveTeam).exists()).toBe(true);
   });
 });

--- a/src/__tests__/views/Brain/RouterAgentsTeam/__snapshots__/ActiveTeam.spec.js.snap
+++ b/src/__tests__/views/Brain/RouterAgentsTeam/__snapshots__/ActiveTeam.spec.js.snap
@@ -11,35 +11,44 @@ exports[`ActiveTeam component > should match snapshot 1`] = `
     data-testid="empty-state"
     data-v-ef307fb1=""
   >
+    <span
+      class="material-symbols-rounded unnnic-icon-scheme--neutral-soft unnnic-icon-size--xl material-symbols-rounded--filled empty__icon"
+      data-testid="material-icon"
+      data-v-9846e6db=""
+      data-v-ef307fb1=""
+      translate="no"
+    >
+      workspaces
+    </span>
     <p
-      class="unnnic-text unnnic-text--size-body-gt unnnic-text--line-height-md unnnic-text--family-secondary unnnic-text--weight-bold unnnic-text--color-neutral-dark"
+      class="unnnic-text unnnic-text--size-body-lg unnnic-text--line-height-md unnnic-text--family-secondary unnnic-text--weight-bold unnnic-text--color-neutral-dark"
       data-v-ec8da4ad=""
       data-v-ef307fb1=""
     >
       
-      No agents in your team
+      No agents assigned into the team
       
     </p>
     <section
       class="empty__description"
       data-v-ef307fb1=""
     >
+      <!-- This comment prevents from auto-capitalizing i18n-t to I18nT which would break the component -->
       <!-- eslint-disable-next-line vue/component-name-in-template-casing -->
       <p
         class="description__text"
         data-v-ef307fb1=""
       >
-        Add agents from the gallery below or 
+        Go to 
         
-        <a
-          class="description__link"
+        <p
+          class="description__assign-agents"
           data-v-ef307fb1=""
-          href="https://github.com/weni-ai/weni-cli"
-          target="_blank"
         >
-          create agent
-        </a>
+          Assign agents
+        </p>
         
+         to view the gallery and add agents to your team
       </p>
     </section>
   </section>

--- a/src/__tests__/views/Brain/RouterAgentsTeam/__snapshots__/ActiveTeam.spec.js.snap
+++ b/src/__tests__/views/Brain/RouterAgentsTeam/__snapshots__/ActiveTeam.spec.js.snap
@@ -5,16 +5,6 @@ exports[`ActiveTeam component > should match snapshot 1`] = `
   class="active-team"
   data-v-ef307fb1=""
 >
-  <h2
-    class="unnnic-text unnnic-text--size-body-lg unnnic-text--line-height-md unnnic-text--family-secondary unnnic-text--weight-bold unnnic-text--color-neutral-darkest"
-    data-testid="title"
-    data-v-ec8da4ad=""
-    data-v-ef307fb1=""
-  >
-    
-    Active team
-    
-  </h2>
   <!--v-if-->
   <section
     class="active-team__empty"

--- a/src/__tests__/views/Brain/RouterAgentsTeam/__snapshots__/RouterAgentsTeam.spec.js.snap
+++ b/src/__tests__/views/Brain/RouterAgentsTeam/__snapshots__/RouterAgentsTeam.spec.js.snap
@@ -5,15 +5,13 @@ exports[`RouterAgentsTeam > matches snapshot 1`] = `
   class="agents-team"
   data-v-d0fbe27f=""
 >
-  <active-team-stub
-    data-v-d0fbe27f=""
-  />
   <unnnic-divider-stub
+    class="agents-team__divider"
     data-v-d0fbe27f=""
     scheme="neutral-soft"
     yspacing="lg"
   />
-  <agents-gallery-stub
+  <active-team-stub
     data-v-d0fbe27f=""
   />
 </section>

--- a/src/components/Brain/BrainHeader.vue
+++ b/src/components/Brain/BrainHeader.vue
@@ -1,5 +1,8 @@
 <template>
-  <header class="header">
+  <header
+    class="header"
+    :class="{ 'header--agents-team': route.name === 'router-agents-team' }"
+  >
     <section class="header__infos">
       <section class="infos__title">
         <p class="title__text">
@@ -17,7 +20,6 @@
     </section>
     <UnnnicButton
       v-if="route.name === 'router-profile'"
-      class="save-button"
       :disabled="profile.isSaveButtonDisabled"
       :loading="profile.isSaving"
       @click="profile.save"
@@ -26,23 +28,30 @@
     </UnnnicButton>
     <UnnnicButton
       v-else-if="route.name === 'router-tunings'"
-      class="save-button"
       :disabled="isTuningsSaveButtonDisabled"
       :loading="isTuningsSaveButtonLoading"
       @click="saveTunings"
     >
       {{ $t('router.tunings.save_changes') }}
     </UnnnicButton>
-    <UnnnicButton
-      v-else-if="route.name === 'router-agents-team'"
-      class="save-button"
-      type="primary"
-      iconLeft="play_arrow"
-      iconsFilled
-      @click="handlePreview"
-    >
-      {{ $t('router.agents_team.preview') }}
-    </UnnnicButton>
+    <template v-else-if="route.name === 'router-agents-team'">
+      <UnnnicButton
+        type="secondary"
+        iconLeft="add"
+        @click="handleAgentsGallery"
+      >
+        {{ $t('router.agents_team.assign_agents') }}
+      </UnnnicButton>
+
+      <UnnnicButton
+        type="primary"
+        iconLeft="play_arrow"
+        iconsFilled
+        @click="handlePreview"
+      >
+        {{ $t('router.agents_team.preview') }}
+      </UnnnicButton>
+    </template>
     <section
       v-else-if="showDateFilter"
       class="monitoring-filters"
@@ -72,6 +81,7 @@ import { useProfileStore } from '@/store/Profile';
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import { useTuningsStore } from '@/store/Tunings';
 import { useAlertStore } from '@/store/Alert';
+import { useAgentsTeamStore } from '@/store/AgentsTeam';
 
 import i18n from '@/utils/plugins/i18n';
 
@@ -164,6 +174,10 @@ watch(
 const handlePreview = () => {
   isPreviewOpen.value = true;
 };
+
+const handleAgentsGallery = () => {
+  useAgentsTeamStore().isAgentsGalleryOpen = true;
+};
 </script>
 
 <style lang="scss" scoped>
@@ -198,11 +212,15 @@ const handlePreview = () => {
       }
     }
   }
+
+  &--agents-team {
+    grid-template-columns: 9fr 3fr 3fr;
+  }
 }
 
-.save-button {
-  width: 18.5 * $unnnic-font-size;
-  margin-left: auto;
+.agents-team-actions {
+  display: flex;
+  gap: $unnnic-spacing-sm;
 }
 
 .monitoring-filters {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -173,7 +173,8 @@
         "no_agent_found": "No agent found"
       },
       "create_agent": "Create agent",
-      "preview": "Preview"
+      "preview": "Preview",
+      "assign_agents": "Assign agents"
     },
     "content": {
       "fields": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -161,9 +161,8 @@
       },
       "active_team": {
         "title": "Active team",
-        "no_team": "No agents in your team",
-        "no_team_description": "Add agents from the gallery below or {link}",
-        "create_agent": "create agent"
+        "no_team": "No agents assigned into the team",
+        "no_team_description": "Go to {assign_agents} to view the gallery and add agents to your team"
       },
       "gallery": {
         "title": "Agents gallery",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -173,7 +173,8 @@
         "no_agent_found": "Ningún agente encontrado"
       },
       "create_agent": "Crear agente",
-      "preview": "Vista previa"
+      "preview": "Vista previa",
+      "assign_agents": "Asignar agentes"
     },
     "content": {
       "fields": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -161,9 +161,8 @@
       },
       "active_team": {
         "title": "Equipo activo",
-        "no_team": "No hay agentes en su equipo",
-        "no_team_description": "Añadir agentes de la galería debajo o {link}",
-        "create_agent": "crear un agente"
+        "no_team": "No hay agentes asignados al equipo",
+        "no_team_description": "Vaya a {assign_agents} para ver la galería y asignar agentes a su equipo"
       },
       "gallery": {
         "title": "Galería de agentes",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -173,7 +173,8 @@
         "no_agent_found": "Nenhum agente encontrado"
       },
       "create_agent": "Crie um agente",
-      "preview": "Preview"
+      "preview": "Preview",
+      "assign_agents": "Atribuir agentes"
     },
     "content": {
       "fields": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -161,9 +161,8 @@
       },
       "active_team": {
         "title": "Equipe ativa",
-        "no_team": "Nenhum agente na sua equipe",
-        "no_team_description": "Adicione agentes da galeria abaixo ou {link}",
-        "create_agent": "crie um agente"
+        "no_team": "Nenhum agente atribuído à sua equipe",
+        "no_team_description": "Vá para {assign_agents} para ver a galeria e atribuir agentes à sua equipe"
       },
       "gallery": {
         "title": "Galeria de agentes",

--- a/src/store/AgentsTeam.js
+++ b/src/store/AgentsTeam.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { reactive } from 'vue';
+import { reactive, ref } from 'vue';
 
 import nexusaiAPI from '@/api/nexusaiAPI.js';
 import { useAlertStore } from './Alert';
@@ -25,6 +25,8 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
     status: null,
     data: [],
   });
+
+  const isAgentsGalleryOpen = ref(false);
 
   async function loadActiveTeam() {
     try {
@@ -109,6 +111,7 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
     activeTeam,
     officialAgents,
     myAgents,
+    isAgentsGalleryOpen,
     loadActiveTeam,
     loadOfficialAgents,
     loadMyAgents,

--- a/src/views/Brain/RouterAgentsTeam/ActiveTeam.vue
+++ b/src/views/Brain/RouterAgentsTeam/ActiveTeam.vue
@@ -29,10 +29,18 @@
       class="active-team__empty"
       data-testid="empty-state"
     >
+      <UnnnicIcon
+        class="empty__icon"
+        size="xl"
+        scheme="neutral-soft"
+        icon="workspaces"
+        filled
+      />
+
       <UnnnicIntelligenceText
         tag="p"
         family="secondary"
-        size="body-gt"
+        size="body-lg"
         color="neutral-dark"
         weight="bold"
       >
@@ -40,19 +48,17 @@
       </UnnnicIntelligenceText>
 
       <section class="empty__description">
+        <!-- This comment prevents from auto-capitalizing i18n-t to I18nT which would break the component -->
         <!-- eslint-disable-next-line vue/component-name-in-template-casing -->
         <i18n-t
           class="description__text"
           keypath="router.agents_team.active_team.no_team_description"
           tag="p"
         >
-          <template #link>
-            <a
-              class="description__link"
-              :href="agentsTeamStore.linkToCreateAgent"
-              target="_blank"
-              >{{ $t('router.agents_team.active_team.create_agent') }}</a
-            >
+          <template #assign_agents>
+            <p class="description__assign-agents">
+              {{ $t('router.agents_team.assign_agents') }}
+            </p>
           </template>
         </i18n-t>
       </section>
@@ -83,42 +89,58 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 .active-team {
-  border-radius: $unnnic-border-radius-md;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-
-  padding: $unnnic-spacing-sm;
-
   display: flex;
   flex-direction: column;
   gap: $unnnic-spacing-sm;
 
   &__empty {
-    border-radius: $unnnic-border-radius-md;
-    border: $unnnic-border-width-thinner dashed $unnnic-color-neutral-cleanest;
+    height: 100%;
 
     padding: $unnnic-spacing-xl $unnnic-spacing-sm;
 
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
 
-    background-color: $unnnic-color-neutral-lightest;
+    .empty__icon {
+      margin-bottom: $unnnic-spacing-ant;
+      font-size: $unnnic-font-size-body-gt * 4;
+    }
 
     .empty__description {
       display: flex;
       align-items: center;
-      gap: 2px;
+      gap: $unnnic-spacing-nano / 2;
 
       .description__text {
         font-family: $unnnic-font-family-secondary;
         font-size: $unnnic-font-size-body-md;
         color: $unnnic-color-neutral-cloudy;
+        display: contents;
       }
 
-      .description__link {
+      .description__assign-agents {
+        position: relative;
+
         font-size: $unnnic-font-size-body-md;
         color: $unnnic-color-neutral-cloudy;
-        text-decoration: underline;
+        font-weight: $unnnic-font-weight-bold;
+
+        cursor: pointer;
+
+        &::after {
+          content: '';
+
+          position: absolute;
+          bottom: 0;
+          left: 0;
+
+          width: 100%;
+          height: 1px;
+
+          background-color: $unnnic-color-neutral-cloudy;
+        }
       }
     }
   }

--- a/src/views/Brain/RouterAgentsTeam/ActiveTeam.vue
+++ b/src/views/Brain/RouterAgentsTeam/ActiveTeam.vue
@@ -56,7 +56,10 @@
           tag="p"
         >
           <template #assign_agents>
-            <p class="description__assign-agents">
+            <p
+              class="description__assign-agents"
+              @click="handleAgentsGallery"
+            >
               {{ $t('router.agents_team.assign_agents') }}
             </p>
           </template>
@@ -81,6 +84,10 @@ const activeTeam = computed(
 const isLoadingTeam = computed(
   () => agentsTeamStore.activeTeam.status === 'loading',
 );
+
+function handleAgentsGallery() {
+  agentsTeamStore.isAgentsGalleryOpen = true;
+}
 
 onMounted(() => {
   agentsTeamStore.loadActiveTeam();

--- a/src/views/Brain/RouterAgentsTeam/ActiveTeam.vue
+++ b/src/views/Brain/RouterAgentsTeam/ActiveTeam.vue
@@ -1,16 +1,5 @@
 <template>
   <section class="active-team">
-    <UnnnicIntelligenceText
-      tag="h2"
-      family="secondary"
-      size="body-lg"
-      color="neutral-darkest"
-      weight="bold"
-      data-testid="title"
-    >
-      {{ $t('router.agents_team.active_team.title') }}
-    </UnnnicIntelligenceText>
-
     <section
       v-if="isLoadingTeam || activeTeam.length"
       class="active-team__cards"

--- a/src/views/Brain/RouterAgentsTeam/index.vue
+++ b/src/views/Brain/RouterAgentsTeam/index.vue
@@ -1,21 +1,25 @@
 <template>
   <section class="agents-team">
+    <UnnnicDivider
+      ySpacing="lg"
+      class="agents-team__divider"
+    />
+
     <ActiveTeam />
-
-    <UnnnicDivider ySpacing="lg" />
-
-    <AgentsGallery />
   </section>
 </template>
 
 <script setup>
 import ActiveTeam from './ActiveTeam.vue';
-import AgentsGallery from './AgentsGallery.vue';
 </script>
 
 <style lang="scss" scoped>
 section.agents-team {
   display: grid;
-  grid-template-rows: auto auto 1fr;
+  grid-template-rows: auto 1fr;
+
+  .agents-team__divider {
+    margin-top: 0;
+  }
 }
 </style>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
A UI improvement to the agent team view was needed before the release of Agent Builder 2.0

### Summary of Changes
- Reorganize RouterAgentsTeam component layout and remove AgentsGallery;
- Add agents gallery handler to BrainHeader and improve responsiveness of actions;
- Updated ActiveTeam design;
- Add agents gallery trigger to ActiveTeam component.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [New agents team design](https://www.figma.com/design/FGfl8EmJCNMz45TX1s3XQO/Agents-Builder-2.0?node-id=1844-7894&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/6115b6e8-98be-417d-aaad-b97ef580d1d2)