### PR TITLE
[NEXUS-2754] - Supervisor of Agent Builder 2.0 

### DIFF
--- a/src/__tests__/api/nexus/monitoring.unit.spec.js
+++ b/src/__tests__/api/nexus/monitoring.unit.spec.js
@@ -151,7 +151,7 @@ describe('Monitoring API', () => {
       });
 
       expect(request.$http.get).toHaveBeenCalledWith(
-        'api/test-uuid/message-detail/123',
+        'api/test-uuid/message-detail/123/',
         {
           hideGenericErrorAlert: true,
         },
@@ -178,7 +178,7 @@ describe('Monitoring API', () => {
       });
 
       expect(request.$http.patch).toHaveBeenCalledWith(
-        'api/test-uuid/message-detail/123',
+        'api/test-uuid/message-detail/123/',
         {
           is_approved: true,
         },

--- a/src/__tests__/views/Brain/Brain.spec.js
+++ b/src/__tests__/views/Brain/Brain.spec.js
@@ -11,6 +11,7 @@ import nexusaiAPI from '@/api/nexusaiAPI';
 import { expect } from 'vitest';
 import { useRoute } from 'vue-router';
 import { createTestingPinia } from '@pinia/testing';
+import { useAgentsTeamStore } from '@/store/AgentsTeam';
 
 const pinia = createTestingPinia({ stubActions: false });
 
@@ -98,6 +99,7 @@ vi.spyOn(nexusaiAPI.intelligences.contentBases.texts, 'list').mockResolvedValue(
 
 describe('Brain Component', () => {
   let wrapper;
+  let agentsTeamStore;
 
   let pushMock;
   beforeEach(() => {
@@ -129,6 +131,12 @@ describe('Brain Component', () => {
         },
       },
     });
+
+    agentsTeamStore = useAgentsTeamStore();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   test('loads content base data correctly', async () => {
@@ -364,5 +372,9 @@ describe('Brain Component', () => {
         }
       });
     }
+  });
+
+  it('should load active team when mounted', () => {
+    expect(agentsTeamStore.loadActiveTeam).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/views/Brain/Brain.spec.js
+++ b/src/__tests__/views/Brain/Brain.spec.js
@@ -1,4 +1,4 @@
-import { flushPromises, mount } from '@vue/test-utils';
+import { flushPromises, mount, shallowMount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import Brain from '@/views/Brain/Brain.vue';
 import RouterContentBase from '@/views/Brain/RouterContentBase.vue';
@@ -12,6 +12,7 @@ import { expect } from 'vitest';
 import { useRoute } from 'vue-router';
 import { createTestingPinia } from '@pinia/testing';
 import { useAgentsTeamStore } from '@/store/AgentsTeam';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 const pinia = createTestingPinia({ stubActions: false });
 
@@ -100,7 +101,7 @@ vi.spyOn(nexusaiAPI.intelligences.contentBases.texts, 'list').mockResolvedValue(
 describe('Brain Component', () => {
   let wrapper;
   let agentsTeamStore;
-
+  let featureFlagsStore;
   let pushMock;
   beforeEach(() => {
     useRoute.mockImplementationOnce(() => ({
@@ -133,6 +134,7 @@ describe('Brain Component', () => {
     });
 
     agentsTeamStore = useAgentsTeamStore();
+    featureFlagsStore = useFeatureFlagsStore();
   });
 
   afterEach(() => {
@@ -374,7 +376,17 @@ describe('Brain Component', () => {
     }
   });
 
-  it('should load active team when mounted', () => {
-    expect(agentsTeamStore.loadActiveTeam).toHaveBeenCalledTimes(1);
+  it('should load active team when mounted if agents team is enabled', () => {
+    featureFlagsStore.flags.agentsTeam = true;
+
+    const loadActiveTeamSpy = vi.spyOn(agentsTeamStore, 'loadActiveTeam');
+
+    wrapper = shallowMount(Brain, {
+      global: {
+        plugins: [store, pinia],
+      },
+    });
+
+    expect(loadActiveTeamSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/views/Brain/RouterAgentsTeam/ActiveTeam.spec.js
+++ b/src/__tests__/views/Brain/RouterAgentsTeam/ActiveTeam.spec.js
@@ -75,10 +75,6 @@ describe('ActiveTeam.vue', () => {
     it('should match snapshot', () => {
       expect(wrapper.element).toMatchSnapshot();
     });
-
-    it('should load active team when mounted', () => {
-      expect(agentsTeamStore.loadActiveTeam).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('Loading state', () => {

--- a/src/__tests__/views/Brain/RouterMonitoring/ReceivedMessages.spec.js
+++ b/src/__tests__/views/Brain/RouterMonitoring/ReceivedMessages.spec.js
@@ -162,11 +162,11 @@ describe('RouterMonitoringReceivedMessages.vue', () => {
       wrapper.vm.filters.text = 'New message';
       await wrapper.vm.$nextTick();
 
-      expect(monitoringStore.loadMessages).toHaveBeenCalledTimes(2);
+      expect(monitoringStore.loadMessages).toHaveBeenCalledTimes(1);
 
       wrapper.vm.filters.tag = [{ value: 'success' }];
       await wrapper.vm.$nextTick();
-      expect(monitoringStore.loadMessages).toHaveBeenCalledTimes(3);
+      expect(monitoringStore.loadMessages).toHaveBeenCalledTimes(2);
     });
 
     it('calls loadMessages on pagination change', async () => {

--- a/src/__tests__/views/Brain/RouterMonitoring/ReceivedMessages.spec.js
+++ b/src/__tests__/views/Brain/RouterMonitoring/ReceivedMessages.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { createRouter, createWebHistory } from 'vue-router';
 import { useMonitoringStore } from '@/store/Monitoring';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import i18n from '@/utils/plugins/i18n';
 import RouterMonitoringReceivedMessages from '@/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue';
 import { createTestingPinia } from '@pinia/testing';
@@ -32,11 +33,14 @@ const pinia = createTestingPinia({
 describe('RouterMonitoringReceivedMessages.vue', () => {
   let wrapper;
   const monitoringStore = useMonitoringStore();
+  let featureFlagsStore;
 
   beforeEach(() => {
     wrapper = mount(RouterMonitoringReceivedMessages, {
       global: { plugins: [pinia, router] },
     });
+
+    featureFlagsStore = useFeatureFlagsStore();
   });
 
   afterEach(() => {

--- a/src/__tests__/views/Brain/RouterMonitoring/ReceivedMessagesHistoryQuestionAndAnswer.spec.js
+++ b/src/__tests__/views/Brain/RouterMonitoring/ReceivedMessagesHistoryQuestionAndAnswer.spec.js
@@ -1,15 +1,26 @@
+import { describe } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
+import { createPinia } from 'pinia';
+
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
+import { useMonitoringStore } from '@/store/Monitoring';
 
 import QuestionAndAnswer from '@/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue';
-import { describe } from 'vitest';
 
 describe('Monitoring messages history QuestionAndAnswer component', () => {
   let wrapper;
+  let featureFlagsStore;
+  let monitoringStore;
+
+  const pinia = createPinia();
 
   beforeEach(() => {
     wrapper = mount(QuestionAndAnswer, {
-      global: { stubs: ['DrawerInspectAnswer'] },
+      global: {
+        stubs: ['DrawerInspectAnswer'],
+        plugins: [pinia],
+      },
       props: {
         isLoading: false,
         data: {
@@ -24,6 +35,9 @@ describe('Monitoring messages history QuestionAndAnswer component', () => {
         },
       },
     });
+
+    featureFlagsStore = useFeatureFlagsStore();
+    monitoringStore = useMonitoringStore();
   });
 
   it('renders response with appropriate class based on llm status', () => {

--- a/src/api/nexus/Monitoring.js
+++ b/src/api/nexus/Monitoring.js
@@ -96,9 +96,9 @@ export const Monitoring = {
       return data;
     },
 
-    async getLogs({ projectUuid }) {
+    async getLogs({ projectUuid, messageId }) {
       const { data } = await request.$http.get(
-        `api/agents/traces/?project=${projectUuid}`,
+        `api/agents/traces/?project=${projectUuid}&log_id=${messageId}`,
       );
 
       return data?.traces;

--- a/src/api/nexus/Monitoring.js
+++ b/src/api/nexus/Monitoring.js
@@ -1,11 +1,5 @@
 import { cleanParams } from '@/utils/http';
-import axios from 'axios';
-
-const request = {
-  $http: axios.create({
-    baseURL: 'https://nexus.apip.stg.cloud.weni.ai',
-  }),
-};
+import request from '@/api/nexusaiRequest';
 
 export const Monitoring = {
   messages: {

--- a/src/api/nexus/Monitoring.js
+++ b/src/api/nexus/Monitoring.js
@@ -92,10 +92,10 @@ export const Monitoring = {
 
     async getLogs({ projectUuid, messageId }) {
       const { data } = await request.$http.get(
-        `api/agents/traces/?project=${projectUuid}&log_id=${messageId}`,
+        `api/agents/traces/?project_uuid=${projectUuid}&log_id=${messageId}`,
       );
 
-      return data?.traces;
+      return data;
     },
   },
 };

--- a/src/api/nexus/Monitoring.js
+++ b/src/api/nexus/Monitoring.js
@@ -1,5 +1,11 @@
-import request from '@/api/nexusaiRequest';
 import { cleanParams } from '@/utils/http';
+import axios from 'axios';
+
+const request = {
+  $http: axios.create({
+    baseURL: 'https://nexus.apip.stg.cloud.weni.ai',
+  }),
+};
 
 export const Monitoring = {
   messages: {
@@ -56,7 +62,7 @@ export const Monitoring = {
 
     async detail({ projectUuid, id }) {
       const { data } = await request.$http.get(
-        `api/${projectUuid}/message-detail/${id}`,
+        `api/${projectUuid}/message-detail/${id}/`,
         { hideGenericErrorAlert: true },
       );
 
@@ -65,7 +71,7 @@ export const Monitoring = {
 
     async rateAnswer({ projectUuid, id, is_approved }) {
       const { data } = await request.$http.patch(
-        `api/${projectUuid}/message-detail/${id}`,
+        `api/${projectUuid}/message-detail/${id}/`,
         { is_approved },
       );
 
@@ -88,6 +94,14 @@ export const Monitoring = {
       );
 
       return data;
+    },
+
+    async getLogs({ projectUuid }) {
+      const { data } = await request.$http.get(
+        `api/agents/traces/?project=${projectUuid}`,
+      );
+
+      return data?.traces;
     },
   },
 };

--- a/src/components/Brain/Preview/PreviewDetails.vue
+++ b/src/components/Brain/Preview/PreviewDetails.vue
@@ -37,7 +37,10 @@
         data-testid="preview-details-logs"
         class="details__logs"
       >
-        <PreviewLogs @scroll-to-bottom="scrollContentToBottom" />
+        <PreviewLogs
+          :logs="previewStore.collaboratorsTraces"
+          @scroll-to-bottom="scrollContentToBottom"
+        />
       </section>
     </section>
   </section>
@@ -48,11 +51,14 @@ import { ref } from 'vue';
 
 import PreviewLogs from '@/components/Brain/PreviewLogs.vue';
 import PreviewVisualFlow from './PreviewVisualFlow.vue';
+import { usePreviewStore } from '@/store/Preview';
 
 const selectedTab = ref('visual_flow');
 const detailTabs = ['visual_flow', 'logs'];
 
 const contentRef = ref(null);
+const previewStore = usePreviewStore();
+
 const scrollContentToBottom = () => {
   contentRef.value.scrollTo({
     top: contentRef.value.scrollHeight,

--- a/src/components/Brain/Preview/__tests__/PreviewDetails.spec.js
+++ b/src/components/Brain/Preview/__tests__/PreviewDetails.spec.js
@@ -1,7 +1,9 @@
 import { mount } from '@vue/test-utils';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia } from 'pinia';
 import Unnnic from '@weni/unnnic-system';
 
+import { usePreviewStore } from '@/store/Preview';
 import i18n from '@/utils/plugins/i18n';
 
 import PreviewLogs from '@/components/Brain/PreviewLogs.vue';
@@ -12,17 +14,24 @@ vi.mock('../PreviewVisualFlow.vue');
 
 describe('PreviewDetails.vue', () => {
   let wrapper;
+  let previewStore;
+
+  const pinia = createPinia();
 
   const createWrapper = (props = {}) => {
     return mount(PreviewDetails, {
       props: {
         ...props,
       },
+      global: {
+        plugins: [pinia],
+      },
     });
   };
 
   beforeEach(() => {
     wrapper = createWrapper();
+    previewStore = usePreviewStore();
   });
 
   const previewDetails = () => wrapper.find('[data-testid="preview-details"]');

--- a/src/components/Brain/PreviewLogs.vue
+++ b/src/components/Brain/PreviewLogs.vue
@@ -107,8 +107,6 @@ const processedLogs = computed(() => {
   const traces = props.logs;
   const { agents: activeTeam, manager } = agentsTeamStore.activeTeam.data || {};
 
-  console.log('activeTeam', activeTeam);
-
   return traces.reduce((logsByAgent, trace) => {
     const agent = activeTeam.find(
       (agent) => agent.external_id === trace.trace.agentId,
@@ -126,8 +124,6 @@ const processedLogs = computed(() => {
       });
     }
 
-    console.log('trace', trace);
-
     logsByAgent.at(-1)?.steps.push({
       title: trace.summary || 'Unknown',
       trace,
@@ -139,7 +135,9 @@ const processedLogs = computed(() => {
 const progressHeight = ref(0);
 
 onMounted(() => {
-  updateProgressBarHeight('mount');
+  nextTick(() => {
+    updateProgressBarHeight('mount');
+  });
 
   if (!agentsTeamStore.activeTeam.data?.manager) {
     agentsTeamStore.loadActiveTeam();

--- a/src/components/Brain/PreviewLogs.vue
+++ b/src/components/Brain/PreviewLogs.vue
@@ -138,10 +138,6 @@ onMounted(() => {
   nextTick(() => {
     updateProgressBarHeight('mount');
   });
-
-  if (!agentsTeamStore.activeTeam.data?.manager) {
-    agentsTeamStore.loadActiveTeam();
-  }
 });
 
 function openModalLogFullDetails(summary, trace) {

--- a/src/components/Brain/PreviewLogs.vue
+++ b/src/components/Brain/PreviewLogs.vue
@@ -79,9 +79,13 @@ import PreviewLogsDetailsModal from './Preview/PreviewLogsDetailsModal.vue';
 const emit = defineEmits(['scroll-to-bottom']);
 
 const props = defineProps({
+  logs: {
+    type: Array,
+    required: true,
+  },
   logsSide: {
     type: String,
-    default: 'right',
+    default: 'left',
     validator(value) {
       return ['left', 'right'].includes(value);
     },
@@ -100,8 +104,10 @@ const selectedLog = ref({
 const processedLogs = computed(() => {
   if (!agentsTeamStore.activeTeam.data) return [];
 
-  const { collaboratorsTraces: traces } = previewStore;
+  const traces = props.logs;
   const { agents: activeTeam, manager } = agentsTeamStore.activeTeam.data || {};
+
+  console.log('activeTeam', activeTeam);
 
   return traces.reduce((logsByAgent, trace) => {
     const agent = activeTeam.find(
@@ -120,6 +126,8 @@ const processedLogs = computed(() => {
       });
     }
 
+    console.log('trace', trace);
+
     logsByAgent.at(-1)?.steps.push({
       title: trace.summary || 'Unknown',
       trace,
@@ -133,7 +141,7 @@ const progressHeight = ref(0);
 onMounted(() => {
   updateProgressBarHeight('mount');
 
-  if (!agentsTeamStore.activeTeam.data) {
+  if (!agentsTeamStore.activeTeam.data?.manager) {
     agentsTeamStore.loadActiveTeam();
   }
 });

--- a/src/components/Brain/__tests__/PreviewLogs.spec.js
+++ b/src/components/Brain/__tests__/PreviewLogs.spec.js
@@ -19,29 +19,23 @@ const mockTeam = {
 const mockTraces = [
   {
     type: 'trace_update',
+    summary: 'First trace summary',
     trace: {
-      summary: 'First trace summary',
-      trace: {
-        agentId: 'agent-1',
-      },
+      agentId: 'agent-1',
     },
   },
   {
     type: 'trace_update',
+    summary: 'Second trace summary',
     trace: {
-      summary: 'Second trace summary',
-      trace: {
-        agentId: 'agent-1',
-      },
+      agentId: 'agent-1',
     },
   },
   {
     type: 'trace_update',
+    summary: 'Manager trace',
     trace: {
-      summary: 'Manager trace',
-      trace: {
-        agentId: 'manager-1',
-      },
+      agentId: 'manager-1',
     },
   },
 ];
@@ -64,6 +58,7 @@ const createWrapper = (props = {}) => {
 
   return mount(PreviewLogs, {
     props: {
+      logs: mockTraces,
       logsSide: 'left',
       ...props,
     },
@@ -134,9 +129,7 @@ describe('PreviewLogs.vue', () => {
     });
 
     it('displays empty message when no logs are available', async () => {
-      previewStore.traces = [];
-
-      await nextTick();
+      await wrapper.setProps({ logs: [] });
 
       expect(emptyMessage().exists()).toBe(true);
       expect(emptyMessage().text()).toBe(
@@ -156,26 +149,24 @@ describe('PreviewLogs.vue', () => {
       expect(processedLogs[1].steps.length).toBe(1);
     });
 
-    it('handles empty traces correctly', () => {
-      previewStore.traces = [];
+    it('handles empty traces correctly', async () => {
+      await wrapper.setProps({ logs: [] });
 
       expect(wrapper.vm.processedLogs).toEqual([]);
     });
 
-    it('handles missing agent correctly', () => {
+    it('handles missing agent correctly', async () => {
       const tracesWithUnknownAgent = [
         {
           type: 'trace_update',
+          summary: 'Unknown agent trace',
           trace: {
-            summary: 'Unknown agent trace',
-            trace: {
-              agentId: 'unknown-agent',
-            },
+            agentId: 'unknown-agent',
           },
         },
       ];
 
-      previewStore.traces = tracesWithUnknownAgent;
+      await wrapper.setProps({ logs: tracesWithUnknownAgent });
 
       expect(wrapper.vm.processedLogs.length).toBe(1);
       expect(wrapper.vm.processedLogs[0].external_id).toBe('manager-1');
@@ -199,7 +190,7 @@ describe('PreviewLogs.vue', () => {
       expect(modal().props('modelValue')).toBeTruthy();
 
       expect(modal().props('title')).toBe('First trace summary');
-      expect(modal().props('trace')).toEqual(mockTraces[0].trace);
+      expect(modal().props('trace')).toEqual(mockTraces[0]);
     });
 
     it('closes modal correctly', async () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,7 +136,8 @@
         "success_alert": "Content added successfully"
       },
       "new_messages_load": "{n} new message. Click to load. | {n} new messages. Click to load.",
-      "show_logs": "Show logs"
+      "show_logs": "Show logs",
+      "hide_logs": "Hide logs"
     },
     "actions": {
       "title": "Actions",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -135,7 +135,8 @@
         "add_another_site": "Add another site",
         "success_alert": "Content added successfully"
       },
-      "new_messages_load": "{n} new message. Click to load. | {n} new messages. Click to load."
+      "new_messages_load": "{n} new message. Click to load. | {n} new messages. Click to load.",
+      "view_logs": "View logs"
     },
     "actions": {
       "title": "Actions",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,7 +136,7 @@
         "success_alert": "Content added successfully"
       },
       "new_messages_load": "{n} new message. Click to load. | {n} new messages. Click to load.",
-      "view_logs": "View logs"
+      "show_logs": "Show logs"
     },
     "actions": {
       "title": "Actions",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -136,7 +136,8 @@
         "success_alert": "Contenido agregado exitosamente"
       },
       "new_messages_load": "{n} mensaje nuevo. Haz clic para cargar. | {n} mensajes nuevos. Haz clic para cargar.",
-      "show_logs": "Mostrar logs"
+      "show_logs": "Mostrar logs",
+      "hide_logs": "Esconder logs"
     },
     "actions": {
       "title": "Acciones",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -135,7 +135,8 @@
         "add_another_site": "Agregar otro sitio",
         "success_alert": "Contenido agregado exitosamente"
       },
-      "new_messages_load": "{n} mensaje nuevo. Haz clic para cargar. | {n} mensajes nuevos. Haz clic para cargar."
+      "new_messages_load": "{n} mensaje nuevo. Haz clic para cargar. | {n} mensajes nuevos. Haz clic para cargar.",
+      "view_logs": "Ver logs"
     },
     "actions": {
       "title": "Acciones",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -136,7 +136,7 @@
         "success_alert": "Contenido agregado exitosamente"
       },
       "new_messages_load": "{n} mensaje nuevo. Haz clic para cargar. | {n} mensajes nuevos. Haz clic para cargar.",
-      "view_logs": "Ver logs"
+      "show_logs": "Mostrar logs"
     },
     "actions": {
       "title": "Acciones",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -136,7 +136,7 @@
         "success_alert": "Conteúdo adicionado com sucesso"
       },
       "new_messages_load": "{n} nova mensagem. Clique para carregar. | {n} novas mensagens. Clique para carregar.",
-      "view_logs": "Ver logs"
+      "show_logs": "Mostrar logs"
     },
     "actions": {
       "title": "Ações",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -136,7 +136,8 @@
         "success_alert": "Conteúdo adicionado com sucesso"
       },
       "new_messages_load": "{n} nova mensagem. Clique para carregar. | {n} novas mensagens. Clique para carregar.",
-      "show_logs": "Mostrar logs"
+      "show_logs": "Mostrar logs",
+      "hide_logs": "Esconder logs"
     },
     "actions": {
       "title": "Ações",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -135,7 +135,8 @@
         "add_another_site": "Adicionar outro site",
         "success_alert": "Conteúdo adicionado com sucesso"
       },
-      "new_messages_load": "{n} nova mensagem. Clique para carregar. | {n} novas mensagens. Clique para carregar."
+      "new_messages_load": "{n} nova mensagem. Clique para carregar. | {n} novas mensagens. Clique para carregar.",
+      "view_logs": "Ver logs"
     },
     "actions": {
       "title": "Ações",

--- a/src/store/Monitoring.js
+++ b/src/store/Monitoring.js
@@ -180,10 +180,11 @@ export const useMonitoringStore = defineStore('monitoring', () => {
     }
   }
 
-  async function loadLogs() {
+  async function loadLogs({ messageId }) {
     try {
       const response = await nexusaiAPI.router.monitoring.messages.getLogs({
         projectUuid: connectProjectUuid.value,
+        messageId,
       });
 
       return response

--- a/src/store/Monitoring.js
+++ b/src/store/Monitoring.js
@@ -180,6 +180,20 @@ export const useMonitoringStore = defineStore('monitoring', () => {
     }
   }
 
+  async function loadLogs() {
+    try {
+      const response = await nexusaiAPI.router.monitoring.messages.getLogs({
+        projectUuid: connectProjectUuid.value,
+      });
+
+      return response
+        .filter((trace) => trace.type === 'trace_update')
+        .map((trace) => trace.trace);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
   async function rateAnswer({ is_approved }) {
     try {
       const response = await nexusaiAPI.router.monitoring.messages.rateAnswer({
@@ -213,6 +227,7 @@ export const useMonitoringStore = defineStore('monitoring', () => {
     loadMessageContext,
     loadMessageDetails,
     loadMessagesPerformance,
+    loadLogs,
     rateAnswer,
     createNewMessage,
     updateMessagesSource,

--- a/src/store/Monitoring.js
+++ b/src/store/Monitoring.js
@@ -117,8 +117,10 @@ export const useMonitoringStore = defineStore('monitoring', () => {
           id: id,
         });
 
-      messages.inspectedAnswer.context.data =
-        response?.map(transformMessageData);
+      messages.inspectedAnswer.context.data = response?.map((item) => ({
+        id: item.id,
+        ...transformMessageData(item),
+      }));
       setStatus('complete');
     } catch (error) {
       setStatus('error');
@@ -187,9 +189,7 @@ export const useMonitoringStore = defineStore('monitoring', () => {
         messageId,
       });
 
-      return response
-        .filter((trace) => trace.type === 'trace_update')
-        .map((trace) => trace.trace);
+      return response;
     } catch (error) {
       console.error(error);
     }

--- a/src/utils/Growthbook.js
+++ b/src/utils/Growthbook.js
@@ -2,11 +2,14 @@ import { reactive } from 'vue';
 import { configureCache, GrowthBook } from '@growthbook/growthbook';
 import globalStore from '@/store';
 
+const gbClientKey = runtimeVariables.get('VITE_GROWTHBOOK_CLIENT_KEY');
+const gbApiHost = runtimeVariables.get('VITE_GROWTHBOOK_API_HOST');
+
 const gbKey = Symbol('growthbook');
 const gbInstance = reactive(
   new GrowthBook({
-    apiHost: runtimeVariables.get('VITE_GROWTHBOOK_API_HOST'),
-    clientKey: runtimeVariables.get('VITE_GROWTHBOOK_CLIENT_KEY'),
+    apiHost: gbApiHost,
+    clientKey: gbClientKey,
     attributes: {
       weni_project: globalStore.state.Auth.connectProjectUuid || '',
       weni_org: globalStore.state.Auth.connectOrgUuid || '',
@@ -20,6 +23,8 @@ configureCache({
 });
 
 const initializeGrowthBook = async () => {
+  if (!gbApiHost || !gbClientKey) return null;
+
   try {
     await gbInstance.init();
     return gbInstance;

--- a/src/views/Brain/Brain.vue
+++ b/src/views/Brain/Brain.vue
@@ -163,9 +163,12 @@ export default {
     });
 
     const brainRoutes = useBrainRoutes();
+    const isAgentsTeamEnabled = computed(
+      () => useFeatureFlagsStore().flags.agentsTeam,
+    );
     const showPreview = computed(
       () =>
-        !useFeatureFlagsStore().flags.agentsTeam &&
+        !isAgentsTeamEnabled.value &&
         brainRoutes.value.find((mappedRoute) => mappedRoute.page === route.name)
           ?.preview,
     );
@@ -272,8 +275,10 @@ export default {
       files.loadNext();
       sites.loadNext();
       useTuningsStore().fetchCredentials();
-      useAgentsTeamStore().loadActiveTeam();
       loadRouterOptions();
+      if (isAgentsTeamEnabled.value) {
+        useAgentsTeamStore().loadActiveTeam();
+      }
     });
 
     const previewActions = computed(() => {

--- a/src/views/Brain/Brain.vue
+++ b/src/views/Brain/Brain.vue
@@ -96,6 +96,7 @@ import BrainWarningBar from '@/components/Brain/BrainWarningBar.vue';
 import BrainHeaderPreview from '@/components/Brain/BrainHeaderPreview.vue';
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import { useTuningsStore } from '@/store/Tunings';
+import { useAgentsTeamStore } from '@/store/AgentsTeam';
 
 export default {
   name: 'Brain',
@@ -271,6 +272,7 @@ export default {
       files.loadNext();
       sites.loadNext();
       useTuningsStore().fetchCredentials();
+      useAgentsTeamStore().loadActiveTeam();
       loadRouterOptions();
     });
 

--- a/src/views/Brain/RouterAgentsTeam/ActiveTeam.vue
+++ b/src/views/Brain/RouterAgentsTeam/ActiveTeam.vue
@@ -89,10 +89,6 @@ const isLoadingTeam = computed(
 function handleAgentsGallery() {
   agentsTeamStore.isAgentsGalleryOpen = true;
 }
-
-onMounted(() => {
-  agentsTeamStore.loadActiveTeam();
-});
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue
@@ -11,7 +11,12 @@
       {{ $t('router.monitoring.received_messages') }}
     </UnnnicIntelligenceText>
 
-    <section class="received-messages__filters">
+    <section
+      :class="[
+        'received-messages__filters',
+        { 'received-messages__filters--agents-team': enableAgentsTeam },
+      ]"
+    >
       <UnnnicInput
         v-model="filters.text"
         iconLeft="search"
@@ -19,6 +24,7 @@
         data-test="filter-text"
       />
       <UnnnicSelectSmart
+        v-if="!enableAgentsTeam"
         v-model="filters.tag"
         :options="tags"
         orderedByIndex
@@ -81,6 +87,7 @@ import Unnnic from '@weni/unnnic-system';
 import { format } from 'date-fns';
 
 import { useMonitoringStore } from '@/store/Monitoring';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 import NewMessages from './NewMessages.vue';
 import ReceivedMessagesHistory from '../RouterMonitoringReceivedMessagesHistory/index.vue';
@@ -96,8 +103,11 @@ const props = defineProps({
 
 const route = useRoute();
 const monitoringStore = useMonitoringStore();
-const t = (key) => i18n.global.t(key);
+const featureFlagsStore = useFeatureFlagsStore();
 
+const enableAgentsTeam = computed(() => featureFlagsStore.flags.agentsTeam);
+
+const t = (key) => i18n.global.t(key);
 const tags = computed(() => [
   {
     value: 'all',
@@ -301,6 +311,10 @@ watch(
     display: grid;
     grid-template-columns: 9fr 3fr;
     gap: $unnnic-spacing-sm;
+
+    &--agents-team {
+      grid-template-columns: 12fr;
+    }
   }
 
   .received-messages__content {

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue
@@ -87,6 +87,13 @@ import ReceivedMessagesHistory from '../RouterMonitoringReceivedMessagesHistory/
 
 import i18n from '@/utils/plugins/i18n';
 
+const props = defineProps({
+  showTags: {
+    type: Boolean,
+    default: true,
+  },
+});
+
 const route = useRoute();
 const monitoringStore = useMonitoringStore();
 const t = (key) => i18n.global.t(key);
@@ -166,21 +173,22 @@ const formattedMessagesRows = computed(() => {
   };
 
   return monitoringStore.messages.data.map(
-    ({ created_at, text, tag, action_name, id }) => ({
-      content: [
-        `${format(new Date(created_at), 'dd/MM/yyyy')}, ${format(new Date(created_at), 'HH:mm')}`,
-        text,
-        {
-          component: Unnnic.unnnicTag,
-          props: {
-            type: 'default',
-            ...getMessageTagProps(tag.toLowerCase(), action_name),
-          },
-          events: {},
+    ({ created_at, text, tag, action_name, id }) => {
+      const date = `${format(new Date(created_at), 'dd/MM/yyyy')}, ${format(new Date(created_at), 'HH:mm')}`;
+      const tagComponent = {
+        component: Unnnic.unnnicTag,
+        props: {
+          type: 'default',
+          ...getMessageTagProps(tag.toLowerCase(), action_name),
         },
-      ],
-      id,
-    }),
+        events: {},
+      };
+
+      return {
+        content: [date, text, props.showTags ? tagComponent : {}],
+        id,
+      };
+    },
   );
 });
 

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue
@@ -259,9 +259,6 @@ function highlightRow(index) {
 watch(
   () => route.query,
   () => getReceivedMessages(),
-  {
-    immediate: true,
-  },
 );
 
 watch(inspectedAnswerIndex, (newIndex) => {

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/MessageContext.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/MessageContext.vue
@@ -20,7 +20,7 @@
     </UnnnicIntelligenceText>
   </button>
 
-  <template v-if="inspectedAnswer.context?.data.length || isLoadingContext">
+  <template v-if="inspectedAnswer.context?.data?.length || isLoadingContext">
     <QuestionAndAnswer
       v-for="fragment of inspectedAnswer.context?.data"
       :key="fragment.id"

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
@@ -92,8 +92,8 @@
               'answer__show-logs',
               { 'answer__show-logs--loading': loadingLogs },
             ]"
-            :disabled="logs.length || loadingLogs"
-            @click="loadLogs"
+            :disabled="loadingLogs"
+            @click="handleShowLogs"
           >
             <section class="show-logs__icon-container">
               <UnnnicIconLoading
@@ -102,7 +102,11 @@
               />
             </section>
             <p class="show-logs__text">
-              {{ $t('router.monitoring.show_logs') }}
+              {{
+                logs.length && showLogs
+                  ? $t('router.monitoring.hide_logs')
+                  : $t('router.monitoring.show_logs')
+              }}
             </p>
           </button>
         </section>
@@ -159,9 +163,18 @@ const isAgentsTeamActive = computed(() => {
   return featureFlagsStore.flags.agentsTeam;
 });
 
-async function loadLogs() {
-  if (loadingLogs.value || logs.value.length) return;
+function handleShowLogs() {
+  if (loadingLogs.value) return;
 
+  if (logs.value.length) {
+    showLogs.value = !showLogs.value;
+    return;
+  }
+
+  loadLogs();
+}
+
+async function loadLogs() {
   loadingLogs.value = true;
 
   try {

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
@@ -149,6 +149,8 @@ const isAgentsTeamActive = computed(() => {
 });
 
 async function loadLogs() {
+  if (loadingLogs.value || logs.value.length) return;
+
   loadingLogs.value = true;
 
   try {

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
@@ -66,6 +66,8 @@
         v-else
         class="question-and-answer__answer"
       >
+        <PreviewLogs v-if="showLogs" />
+
         <Markdown
           data-testid="answer"
           :class="[
@@ -100,13 +102,16 @@ import { ref } from 'vue';
 
 import DrawerInspectAnswer from '@/components/Brain/Monitoring/DrawerInspectResponse/index.vue';
 import Markdown from '@/components/Markdown.vue';
-
+import PreviewLogs from '@/components/Brain/PreviewLogs.vue';
 const props = defineProps({
   isLoading: {
     type: Boolean,
     default: true,
   },
-
+  showLogs: {
+    type: Boolean,
+    default: false,
+  },
   data: {
     type: Object,
     required: true,
@@ -143,7 +148,7 @@ const isDrawerInspectAnswerOpen = ref(false);
 
     padding: $unnnic-spacing-ant;
 
-    background-color: $unnnic-color-neutral-light;
+    background-color: $unnnic-color-background-solo;
 
     color: $unnnic-color-neutral-dark;
     font-family: $unnnic-font-family-secondary;

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
@@ -78,7 +78,16 @@
           :content="data.llm.response"
         />
 
+        <button
+          v-if="featureFlagsStore.flags.agentsTeam"
+          class="answer__show-logs"
+          @click="showLogs = true"
+        >
+          {{ $t('router.monitoring.show_logs') }}
+        </button>
+
         <UnnnicButton
+          v-else
           class="answer__inspect-response"
           data-testid="inspect-response"
           size="small"
@@ -103,20 +112,21 @@ import { ref } from 'vue';
 import DrawerInspectAnswer from '@/components/Brain/Monitoring/DrawerInspectResponse/index.vue';
 import Markdown from '@/components/Markdown.vue';
 import PreviewLogs from '@/components/Brain/PreviewLogs.vue';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
+
 const props = defineProps({
   isLoading: {
     type: Boolean,
     default: true,
-  },
-  showLogs: {
-    type: Boolean,
-    default: false,
   },
   data: {
     type: Object,
     required: true,
   },
 });
+
+const featureFlagsStore = useFeatureFlagsStore();
+const showLogs = ref(false);
 
 const isDrawerInspectAnswerOpen = ref(false);
 </script>
@@ -160,6 +170,8 @@ const isDrawerInspectAnswerOpen = ref(false);
   }
 
   &__answer {
+    position: relative;
+
     display: flex;
     flex-direction: column;
     align-items: flex-end;
@@ -169,6 +181,7 @@ const isDrawerInspectAnswerOpen = ref(false);
 
     &-text {
       justify-self: flex-end;
+      padding: $unnnic-spacing-sm $unnnic-spacing-ant;
 
       &--success,
       &--action {
@@ -184,6 +197,26 @@ const isDrawerInspectAnswerOpen = ref(false);
 
     .answer__inspect-response {
       width: 100%;
+    }
+
+    .answer__show-logs {
+      position: absolute;
+      left: $unnnic-spacing-ant;
+      bottom: -($unnnic-spacing-xl) / 4;
+
+      border-radius: $unnnic-border-radius-pill;
+      border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+      background: $unnnic-color-neutral-white;
+      box-shadow: 0px 0px $unnnic-spacing-xs 0 rgba(0, 0, 0, 0.08);
+
+      padding: calc($unnnic-spacing-nano / 2) $unnnic-spacing-ant;
+
+      color: $unnnic-color-neutral-cloudy;
+      font-family: $unnnic-font-family-secondary;
+      font-size: $unnnic-font-size-body-md;
+      line-height: $unnnic-line-height-md * 1.75;
+
+      cursor: pointer;
     }
   }
 

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
@@ -178,7 +178,9 @@ async function loadLogs() {
   loadingLogs.value = true;
 
   try {
-    logs.value = await monitoringStore.loadLogs();
+    logs.value = await monitoringStore.loadLogs({
+      messageId: props.data.id,
+    });
 
     showLogs.value = true;
   } catch (error) {

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
@@ -88,11 +88,22 @@
 
           <button
             v-if="isAgentsTeamActive"
-            class="answer__show-logs"
-            :disabled="logs.length"
+            :class="[
+              'answer__show-logs',
+              { 'answer__show-logs--loading': loadingLogs },
+            ]"
+            :disabled="logs.length || loadingLogs"
             @click="loadLogs"
           >
-            {{ $t('router.monitoring.show_logs') }}
+            <section class="show-logs__icon-container">
+              <UnnnicIconLoading
+                size="sm"
+                class="show-logs__icon"
+              />
+            </section>
+            <p class="show-logs__text">
+              {{ $t('router.monitoring.show_logs') }}
+            </p>
           </button>
         </section>
 
@@ -247,10 +258,7 @@ async function loadLogs() {
 
       padding: calc($unnnic-spacing-nano / 2) $unnnic-spacing-ant;
 
-      color: $unnnic-color-neutral-cloudy;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-md;
-      line-height: $unnnic-line-height-md * 1.75;
+      display: flex;
 
       cursor: pointer;
 
@@ -263,6 +271,40 @@ async function loadLogs() {
         background-color: $unnnic-color-neutral-soft;
         color: $unnnic-color-neutral-clean;
         cursor: not-allowed;
+      }
+
+      .show-logs__text,
+      .show-logs__icon {
+        color: $unnnic-color-neutral-cloudy;
+        font-size: $unnnic-font-size-body-md;
+      }
+
+      .show-logs__text {
+        font-family: $unnnic-font-family-secondary;
+        line-height: $unnnic-line-height-md * 1.75;
+      }
+
+      .show-logs__icon {
+        opacity: 0;
+      }
+
+      .show-logs__icon-container {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+
+        display: flex;
+      }
+
+      &--loading {
+        .show-logs__text {
+          opacity: 0;
+        }
+
+        .show-logs__icon {
+          opacity: 1;
+        }
       }
     }
   }

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/index.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/index.vue
@@ -31,6 +31,16 @@
         @click="close"
       />
     </header>
+
+    <UnnnicSwitch
+      v-if="featureFlagsStore.flags.agentsTeam"
+      class="received-messages-history__logs-switch"
+      :textRight="$t('router.monitoring.view_logs')"
+      size="small"
+      :modelValue="showAgentsLogs"
+      @update:model-value="showAgentsLogs = !showAgentsLogs"
+    />
+
     <section class="received-messages-history__messages">
       <MessageContext v-if="!isLoadingMessages" />
 
@@ -38,19 +48,26 @@
         data-testid="question-and-answer"
         :isLoading="isLoadingMessages"
         :data="inspectedAnswer"
+        :showLogs="showAgentsLogs"
       />
     </section>
   </section>
 </template>
 
 <script setup>
+import { computed, ref, watch } from 'vue';
+
 import { useMonitoringStore } from '@/store/Monitoring';
-import { computed, watch } from 'vue';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 import MessageContext from './MessageContext.vue';
 import QuestionAndAnswer from './QuestionAndAnswer.vue';
 
 const monitoringStore = useMonitoringStore();
+const featureFlagsStore = useFeatureFlagsStore();
+
+const showAgentsLogs = ref(false);
+
 const inspectedAnswer = computed(
   () => monitoringStore.messages.inspectedAnswer,
 );
@@ -80,6 +97,9 @@ watch(
 </script>
 
 <style lang="scss" scoped>
+$border-bottom: $unnnic-border-width-thinner solid
+  $unnnic-color-neutral-cleanest;
+
 .received-messages-history {
   box-sizing: border-box;
 
@@ -88,8 +108,7 @@ watch(
   gap: $unnnic-spacing-xs;
 
   &__header {
-    border-bottom: $unnnic-border-width-thinner solid
-      $unnnic-color-neutral-cleanest;
+    border-bottom: $border-bottom;
 
     padding: $unnnic-spacing-ant $unnnic-spacing-sm;
 
@@ -103,6 +122,12 @@ watch(
       overflow: hidden;
       text-overflow: ellipsis;
     }
+  }
+
+  &__logs-switch {
+    border-bottom: $border-bottom;
+
+    padding: 0 0 $unnnic-spacing-xs $unnnic-spacing-sm;
   }
 
   &__messages {

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/index.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/index.vue
@@ -32,15 +32,6 @@
       />
     </header>
 
-    <UnnnicSwitch
-      v-if="featureFlagsStore.flags.agentsTeam"
-      class="received-messages-history__logs-switch"
-      :textRight="$t('router.monitoring.view_logs')"
-      size="small"
-      :modelValue="showAgentsLogs"
-      @update:model-value="showAgentsLogs = !showAgentsLogs"
-    />
-
     <section class="received-messages-history__messages">
       <MessageContext v-if="!isLoadingMessages" />
 
@@ -48,14 +39,13 @@
         data-testid="question-and-answer"
         :isLoading="isLoadingMessages"
         :data="inspectedAnswer"
-        :showLogs="showAgentsLogs"
       />
     </section>
   </section>
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue';
+import { computed, watch } from 'vue';
 
 import { useMonitoringStore } from '@/store/Monitoring';
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
@@ -65,8 +55,6 @@ import QuestionAndAnswer from './QuestionAndAnswer.vue';
 
 const monitoringStore = useMonitoringStore();
 const featureFlagsStore = useFeatureFlagsStore();
-
-const showAgentsLogs = ref(false);
 
 const inspectedAnswer = computed(
   () => monitoringStore.messages.inspectedAnswer,
@@ -122,12 +110,6 @@ $border-bottom: $unnnic-border-width-thinner solid
       overflow: hidden;
       text-overflow: ellipsis;
     }
-  }
-
-  &__logs-switch {
-    border-bottom: $border-bottom;
-
-    padding: 0 0 $unnnic-spacing-xs $unnnic-spacing-sm;
   }
 
   &__messages {

--- a/src/views/Brain/RouterMonitoring/index.vue
+++ b/src/views/Brain/RouterMonitoring/index.vue
@@ -6,9 +6,15 @@
       class="router-monitoring__divider"
     />
 
-    <RouterMonitoringPerformance data-testid="performance" />
+    <RouterMonitoringPerformance
+      v-if="!enableAgentsTeam"
+      data-testid="performance"
+    />
 
-    <RouterMonitoringReceivedMessages data-testid="received-messages" />
+    <RouterMonitoringReceivedMessages
+      :showTags="!enableAgentsTeam"
+      data-testid="received-messages"
+    />
   </section>
 </template>
 
@@ -18,6 +24,7 @@ import WS from '@/websocket/setup';
 import { computed, onMounted, ref } from 'vue';
 import { useStore } from 'vuex';
 import { useMonitoringStore } from '@/store/Monitoring';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 import RouterMonitoringPerformance from './RouterMonitoringPerformance.vue';
 import RouterMonitoringReceivedMessages from './RouterMonitoringReceivedMessages/index.vue';
@@ -26,6 +33,9 @@ const ws = ref(null);
 const store = useStore();
 const auth = computed(() => store.state.Auth);
 const monitoringStore = useMonitoringStore();
+const featureFlagsStore = useFeatureFlagsStore();
+
+const enableAgentsTeam = computed(() => featureFlagsStore.flags.agentsTeam);
 
 function connectMonitoringWS() {
   if (monitoringStore.ws) return;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
In order for Agent Builder 2.0 users to have an initial tracking of the agent's messages, it was necessary to add the message traces to the supervisor.

### Summary of Changes
- Changed the PreviewLogs component to receive logs via props instead of getting them directly from the store;
- Added the trace request for Agent Builder 2.0 supervisor messages;
- Temporarily removed the Agent Builder 2.0 Supervisor performance session;
- Adjusted the QuestionAndAnswer component to have the show/hide logs functionality.

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/5416c76e-7669-470e-a060-3ee243ebcabf)
