### PR TITLE
[NEXUS-2754] - Hotfix Supervisor

### DIFF
--- a/src/components/Brain/PreviewLogs.vue
+++ b/src/components/Brain/PreviewLogs.vue
@@ -125,12 +125,42 @@ const processedLogs = computed(() => {
     }
 
     logsByAgent.at(-1)?.steps.push({
-      title: trace.summary || 'Unknown',
+      title: getTraceSummary(trace) || 'Unknown',
       trace,
     });
     return logsByAgent;
   }, []);
 });
+
+function getTraceSummary(trace) {
+  if (trace.summary) {
+    return trace.summary;
+  }
+
+  function capitalizeWord(word) {
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  }
+
+  function formatTraceKey(key) {
+    return key
+      .split(/(?=[A-Z])|_/)
+      .map(capitalizeWord)
+      .join(' ');
+  }
+
+  function findTraceKey(traceObject) {
+    return Object.keys(traceObject).find((key) =>
+      key.toLowerCase().includes('trace'),
+    );
+  }
+
+  if (!trace.trace || typeof trace.trace !== 'object') {
+    return 'Unknown';
+  }
+
+  const traceKey = findTraceKey(trace.trace);
+  return traceKey ? formatTraceKey(traceKey) : 'Unknown';
+}
 
 const progressHeight = ref(0);
 

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessages/index.vue
@@ -365,7 +365,7 @@ watch(
       }
 
       &--history-opened {
-        min-height: 25vh;
+        min-height: 65vh;
         height: 100%;
 
         overflow: hidden;

--- a/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
+++ b/src/views/Brain/RouterMonitoring/RouterMonitoringReceivedMessagesHistory/QuestionAndAnswer.vue
@@ -132,7 +132,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import DrawerInspectAnswer from '@/components/Brain/Monitoring/DrawerInspectResponse/index.vue';
 import Markdown from '@/components/Markdown.vue';
@@ -189,6 +189,14 @@ async function loadLogs() {
     loadingLogs.value = false;
   }
 }
+
+watch(
+  () => props.data.id,
+  () => {
+    showLogs.value = false;
+    logs.value = [];
+  },
+);
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Some improvements have been found in Supervisor for Agent Builder 2.0.

### Summary of Changes
- Increase min-height for history section at QuestionAndAnswer;
- Add watch for data.id prop at QuestionAndAnswer to reset logs when messages changes;
- Enhance trace summary retrieval with improved formatting and fallback logic.
