### PR TITLE
[NEXUS-2862] - Removed temporaly Agent Builder 2.0 settings tab at Tuning view

### DIFF
--- a/src/views/Brain/RouterTunings.vue
+++ b/src/views/Brain/RouterTunings.vue
@@ -48,13 +48,13 @@ const isAgentsTeamEnabled = useFeatureFlagsStore().flags.agentsTeam;
 
 const tabs = ref(
   [
-    { title: 'config', page: 'config' },
+    isAgentsTeamEnabled ? null : { title: 'config', page: 'config' },
     isAgentsTeamEnabled ? { title: 'credentials', page: 'credentials' } : null,
     { title: 'history', page: 'hist' },
   ].filter((obj) => obj),
 );
 
-const activeTab = ref('config');
+const activeTab = ref(isAgentsTeamEnabled ? 'credentials' : 'config');
 
 const props = defineProps({
   data: {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
The deployment of the Agent Builder 2.0 progressive feedback field backend has been delayed, so the frontend is not working yet.

### Summary of Changes
- Update tunings tabs logic based on agents team feature flag
