### PR TITLE
[NEXUS-2885] - Fix preview clear conversations

### DIFF
--- a/src/components/Brain/Preview/PreviewDrawer.vue
+++ b/src/components/Brain/Preview/PreviewDrawer.vue
@@ -38,7 +38,7 @@
           data-testid="preview-drawer-preview"
           class="content__preview"
         >
-          <Preview :key="refreshPreviewValue" />
+          <Preview />
         </section>
 
         <section
@@ -53,8 +53,9 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { usePreviewStore } from '@/store/Preview';
+import { useFlowPreviewStore } from '@/store/FlowPreview';
 
 import Preview from '@/views/repository/content/Preview.vue';
 import PreviewDetails from './PreviewDetails.vue';
@@ -71,7 +72,7 @@ const props = defineProps({
 defineEmits(['update:modelValue']);
 
 const previewStore = usePreviewStore();
-
+const flowPreviewStore = useFlowPreviewStore();
 watch(
   () => props.modelValue,
   (isModalOpen) => {
@@ -88,11 +89,9 @@ const previewHeaderActions = computed(() => [
   },
 ]);
 
-const refreshPreviewValue = ref(0);
-
 function refreshPreview() {
-  refreshPreviewValue.value += 1;
   previewStore.clearTraces();
+  flowPreviewStore.clearMessages();
 }
 </script>
 

--- a/src/components/Brain/Preview/__tests__/PreviewDrawer.spec.js
+++ b/src/components/Brain/Preview/__tests__/PreviewDrawer.spec.js
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
 import { usePreviewStore } from '@/store/Preview';
+import { useFlowPreviewStore } from '@/store/FlowPreview';
 import WS from '@/websocket/setup';
 import i18n from '@/utils/plugins/i18n';
 
@@ -29,7 +30,7 @@ describe('PreviewDrawer.vue', () => {
   let connectMock;
 
   const previewStore = usePreviewStore();
-
+  const flowPreviewStore = useFlowPreviewStore();
   beforeEach(() => {
     previewStore.ws = null;
     connectMock = vi.fn();
@@ -108,10 +109,9 @@ describe('PreviewDrawer.vue', () => {
   });
 
   it('should refresh preview when refresh action is clicked', async () => {
-    const initialRefreshValue = wrapper.vm.refreshPreviewValue;
     await wrapper.vm.previewHeaderActions[0].onClick();
 
-    expect(wrapper.vm.refreshPreviewValue).toBe(initialRefreshValue + 1);
     expect(previewStore.clearTraces).toHaveBeenCalled();
+    expect(flowPreviewStore.clearMessages).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
In Agent Builder 2.0, the preview clear conversations button is not working.

### Summary of Changes
Instead of updating the component's key as was done before, after the preview refactoring, the clear now needs to be done in the store.
