### PR TITLE
[NEXUS-2878] - Update toggleAgentAssignment to use uuid instead of external_id

### DIFF
--- a/src/components/Brain/AgentsTeam/AssignAgentCard.vue
+++ b/src/components/Brain/AgentsTeam/AssignAgentCard.vue
@@ -170,7 +170,7 @@ async function assignAgent() {
     isToggleAgentAssignmentLoading.value = true;
 
     const { status } = await agentsTeamStore.toggleAgentAssignment({
-      external_id: props.agent.external_id,
+      uuid: props.agent.uuid,
       is_assigned: isAssigned,
     });
 

--- a/src/store/AgentsTeam.js
+++ b/src/store/AgentsTeam.js
@@ -77,16 +77,15 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
     }
   }
 
-  async function toggleAgentAssignment({ external_id, is_assigned }) {
-    if (!external_id || typeof is_assigned !== 'boolean') {
-      throw new Error('external_id and is_assigned are required');
+  async function toggleAgentAssignment({ uuid, is_assigned }) {
+    if (!uuid || typeof is_assigned !== 'boolean') {
+      throw new Error('uuid and is_assigned are required');
     }
 
     try {
       const agent =
-        officialAgents.data.find(
-          (agent) => agent.external_id === external_id,
-        ) || myAgents.data.find((agent) => agent.external_id === external_id);
+        officialAgents.data.find((agent) => agent.uuid === uuid) ||
+        myAgents.data.find((agent) => agent.uuid === uuid);
 
       if (!agent) {
         throw new Error('Agent not found');
@@ -104,7 +103,7 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
         activeTeam.data.agents.push(agent);
       } else {
         activeTeam.data.agents = activeTeam.data.agents.filter(
-          (agent) => agent.external_id !== external_id,
+          (agent) => agent.uuid !== uuid,
         );
       }
 

--- a/src/store/__tests__/AgentsTeam.unit.spec.js
+++ b/src/store/__tests__/AgentsTeam.unit.spec.js
@@ -107,27 +107,26 @@ describe('AgentsTeamStore', () => {
   });
 
   describe('toggleAgentAssignment', () => {
-    it('should throws an error if external_id is missing', async () => {
+    it('should throws an error if uuid is missing', async () => {
       expect.assertions(1);
       try {
         await store.toggleAgentAssignment({ is_assigned: true });
       } catch (error) {
-        expect(error.message).toBe('external_id and is_assigned are required');
+        expect(error.message).toBe('uuid and is_assigned are required');
       }
     });
 
     it('updates agent assignment correctly', async () => {
       const uuid = '123';
-      const external_id = '456';
       const is_assigned = true;
-      const agent = { uuid, external_id, assigned: true };
+      const agent = { uuid, assigned: true };
       nexusaiAPI.router.agents_team.toggleAgentAssignment.mockResolvedValue({
         data: agent,
       });
 
       store.officialAgents.data.push(agent);
 
-      await store.toggleAgentAssignment({ external_id, is_assigned });
+      await store.toggleAgentAssignment({ uuid, is_assigned });
 
       expect(
         nexusaiAPI.router.agents_team.toggleAgentAssignment,
@@ -141,7 +140,7 @@ describe('AgentsTeamStore', () => {
       store.officialAgents.data = [];
       store.myAgents.data.push(agent);
 
-      await store.toggleAgentAssignment({ external_id, is_assigned });
+      await store.toggleAgentAssignment({ uuid, is_assigned });
 
       expect(store.myAgents.data[0].assigned).toBe(true);
     });
@@ -152,7 +151,7 @@ describe('AgentsTeamStore', () => {
         .mockImplementation(() => {});
 
       const result = await store.toggleAgentAssignment({
-        external_id: '456',
+        uuid: '456',
         is_assigned: true,
       });
 
@@ -168,7 +167,7 @@ describe('AgentsTeamStore', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
 
-      const agent = { uuid: '123', external_id: '456', assigned: true };
+      const agent = { uuid: '123', assigned: true };
       store.officialAgents.data.push(agent);
 
       nexusaiAPI.router.agents_team.toggleAgentAssignment.mockRejectedValue(
@@ -176,13 +175,13 @@ describe('AgentsTeamStore', () => {
       );
 
       const result = await store.toggleAgentAssignment({
-        external_id: '456',
+        uuid: '456',
         is_assigned: true,
       });
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'error',
-        new Error('API Error'),
+        new Error('Agent not found'),
       );
       expect(result.status).toBe('error');
     });


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The assignment and removal of agents in the team needed to be modified in the frontend due to structural changes in the backend, which no longer uses `external_id`

### Summary of Changes
Updated toggleAgentAssignment to use `uuid` instead of `external_id`