### PR TITLE
[NEXUS-2903] Fix preview context persistence

### DIFF
--- a/src/components/Brain/Preview/PreviewDrawer.vue
+++ b/src/components/Brain/Preview/PreviewDrawer.vue
@@ -54,6 +54,8 @@
 
 <script setup>
 import { computed, watch } from 'vue';
+import { useStore } from 'vuex';
+
 import { usePreviewStore } from '@/store/Preview';
 import { useFlowPreviewStore } from '@/store/FlowPreview';
 
@@ -71,6 +73,7 @@ const props = defineProps({
 
 defineEmits(['update:modelValue']);
 
+const store = useStore();
 const previewStore = usePreviewStore();
 const flowPreviewStore = useFlowPreviewStore();
 watch(
@@ -92,6 +95,9 @@ const previewHeaderActions = computed(() => [
 function refreshPreview() {
   previewStore.clearTraces();
   flowPreviewStore.clearMessages();
+  flowPreviewStore.previewInit({
+    contentBaseUuid: store.state.router.contentBaseUuid,
+  });
 }
 </script>
 

--- a/src/components/Brain/Preview/__tests__/PreviewDrawer.spec.js
+++ b/src/components/Brain/Preview/__tests__/PreviewDrawer.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
@@ -15,6 +16,14 @@ const pinia = createTestingPinia({
     preview: {
       ws: null,
     },
+  },
+});
+
+const store = createStore({
+  state() {
+    return {
+      router: { contentBaseUuid: '123' },
+    };
   },
 });
 
@@ -44,7 +53,7 @@ describe('PreviewDrawer.vue', () => {
         modelValue: true,
       },
       global: {
-        plugins: [pinia],
+        plugins: [pinia, store],
         stubs: {
           PreviewDetails: true,
           Preview: true,

--- a/src/views/repository/content/Preview.vue
+++ b/src/views/repository/content/Preview.vue
@@ -381,6 +381,8 @@ function scrollToLastMessage() {
 }
 
 function initPreview() {
+  if (flowPreviewStore.preview.contact.uuid) return;
+
   flowPreviewStore.previewInit({
     contentBaseUuid: store.state.router.contentBaseUuid,
   });
@@ -391,8 +393,6 @@ function initPreview() {
 }
 
 onMounted(() => {
-  if (flowPreviewStore.preview.contact.uuid) return;
-
   initPreview();
 });
 </script>

--- a/src/views/repository/content/Preview.vue
+++ b/src/views/repository/content/Preview.vue
@@ -380,7 +380,7 @@ function scrollToLastMessage() {
   });
 }
 
-onMounted(() => {
+function initPreview() {
   flowPreviewStore.previewInit({
     contentBaseUuid: store.state.router.contentBaseUuid,
   });
@@ -388,6 +388,12 @@ onMounted(() => {
   window.brainPreviewAddMessage = (messageData) => {
     flowPreviewStore.addMessage(messageData);
   };
+}
+
+onMounted(() => {
+  if (flowPreviewStore.preview.contact.uuid) return;
+
+  initPreview();
 });
 </script>
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Whenever the agent builder 2.0 preview was closed, the agent lost the context, but the messages remained on the screen. 

### Summary of Changes
Added a validation to only send a new urn to the request (which changes the context), if the user clicks on "clear conversations".
