### PR TITLE
[NEXUS-2971] - Fix preview logs bugs

### DIFF
--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -30,6 +30,7 @@ export const AgentsTeam = {
           assigned,
           credentials,
           is_official,
+          slug,
         }) => ({
           uuid,
           name,
@@ -38,6 +39,7 @@ export const AgentsTeam = {
           assigned,
           credentials,
           is_official,
+          id: slug,
         }),
       ),
     };
@@ -64,6 +66,7 @@ export const AgentsTeam = {
           assigned,
           credentials,
           is_official,
+          slug,
         }) => ({
           uuid,
           name,
@@ -72,6 +75,7 @@ export const AgentsTeam = {
           assigned,
           credentials,
           is_official,
+          id: slug,
         }),
       ),
     };

--- a/src/components/Brain/__tests__/PreviewLogs.spec.js
+++ b/src/components/Brain/__tests__/PreviewLogs.spec.js
@@ -8,7 +8,7 @@ import PreviewLogs from '../PreviewLogs.vue';
 import { usePreviewStore } from '@/store/Preview';
 import { useAgentsTeamStore } from '@/store/AgentsTeam';
 
-const mockTeam = {
+const mockAllAgents = {
   agents: [
     { id: 'agent-1', name: 'Test Agent 1' },
     { id: 'agent-2', name: 'Test Agent 2' },
@@ -54,16 +54,9 @@ const mockTraces = [
 
 const createWrapper = (props = {}) => {
   const pinia = createTestingPinia({
-    createSpy: vi.fn,
     initialState: {
       preview: {
         traces: [...mockTraces],
-      },
-      AgentsTeam: {
-        activeTeam: {
-          data: { ...mockTeam },
-          status: 'complete',
-        },
       },
     },
   });
@@ -114,6 +107,7 @@ describe('PreviewLogs.vue', () => {
     wrapper = createWrapper();
     previewStore = usePreviewStore();
     agentsTeamStore = useAgentsTeamStore();
+    agentsTeamStore.allAgents = mockAllAgents;
   });
 
   afterEach(() => {

--- a/src/components/Brain/__tests__/__snapshots__/PreviewLogs.spec.js.snap
+++ b/src/components/Brain/__tests__/__snapshots__/PreviewLogs.spec.js.snap
@@ -4,7 +4,7 @@ exports[`PreviewLogs.vue > Component rendering > matches snapshot 1`] = `
 "<section data-v-6e9a8500="" data-testid="preview-logs" class="preview-logs preview-logs--left">
   <!--v-if-->
   <ol data-v-6e9a8500="" class="preview-logs__logs preview-logs__logs--left">
-    <li data-v-6e9a8500="" class="logs__log logs__log--left" data-testid="preview-logs-log">
+    <li data-v-6e9a8500="" class="logs__log logs__log--left logs-enter-from logs-enter-active" data-testid="preview-logs-log">
       <p data-v-6e9a8500="" class="log__agent-name log__agent-name--left" data-testid="preview-logs-log-agent-name">Test Agent 1</p>
       <ol data-v-6e9a8500="" class="log__steps">
         <li data-v-6e9a8500="" class="steps__step steps__step--left" data-testid="preview-logs-log-step">
@@ -15,7 +15,7 @@ exports[`PreviewLogs.vue > Component rendering > matches snapshot 1`] = `
         </li>
       </ol>
     </li>
-    <li data-v-6e9a8500="" class="logs__log logs__log--left" data-testid="preview-logs-log">
+    <li data-v-6e9a8500="" class="logs__log logs__log--left logs-enter-from logs-enter-active" data-testid="preview-logs-log">
       <p data-v-6e9a8500="" class="log__agent-name log__agent-name--left" data-testid="preview-logs-log-agent-name">Manager</p>
       <ol data-v-6e9a8500="" class="log__steps">
         <li data-v-6e9a8500="" class="steps__step steps__step--left" data-testid="preview-logs-log-step">

--- a/src/store/AgentsTeam.js
+++ b/src/store/AgentsTeam.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { reactive, ref } from 'vue';
+import { computed, reactive, ref } from 'vue';
 
 import nexusaiAPI from '@/api/nexusaiAPI.js';
 import { useAlertStore } from './Alert';
@@ -24,6 +24,13 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
   const myAgents = reactive({
     status: null,
     data: [],
+  });
+
+  const allAgents = computed(() => {
+    return {
+      manager: activeTeam.data.manager,
+      agents: [...officialAgents.data, ...myAgents.data],
+    };
   });
 
   const isAgentsGalleryOpen = ref(false);
@@ -194,6 +201,7 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
     activeTeam,
     officialAgents,
     myAgents,
+    allAgents,
     isAgentsGalleryOpen,
     loadActiveTeam,
     loadOfficialAgents,

--- a/src/views/AgentBuilder/AgentsTeam/AgentsGalleryModal.vue
+++ b/src/views/AgentBuilder/AgentsTeam/AgentsGalleryModal.vue
@@ -184,11 +184,6 @@ function openCLI() {
   window.open(agentsTeamStore.linkToCreateAgent, '_blank');
 }
 
-onMounted(() => {
-  agentsTeamStore.loadOfficialAgents();
-  agentsTeamStore.loadMyAgents();
-});
-
 const debouncedSearch = (callback) => debounce(callback, 300);
 watch(
   () => search.value['my-agents'],

--- a/src/views/AgentBuilder/__tests__/AgentsTeam/AgentsGalleryModal.spec.js
+++ b/src/views/AgentBuilder/__tests__/AgentsTeam/AgentsGalleryModal.spec.js
@@ -108,11 +108,6 @@ describe('AgentsGalleryModal.vue', () => {
     it('renders agent cards', () => {
       expect(assignAgentCards().length).toBe(2);
     });
-
-    it('loads official and my agents when mounted', () => {
-      expect(agentsTeamStore.loadOfficialAgents).toHaveBeenCalledTimes(1);
-      expect(agentsTeamStore.loadMyAgents).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('Loading states', () => {

--- a/src/views/AgentBuilder/index.vue
+++ b/src/views/AgentBuilder/index.vue
@@ -43,6 +43,8 @@ import ModalSaveChangesError from '../Brain/ModalSaveChangesError.vue';
 const route = useRoute();
 const store = useStore();
 
+const agentsTeamStore = useAgentsTeamStore();
+
 const currentView = computed(() => {
   const views = {
     knowledge: Knowledge,
@@ -57,7 +59,9 @@ const currentView = computed(() => {
 
 onMounted(() => {
   useTuningsStore().fetchCredentials();
-  useAgentsTeamStore().loadActiveTeam();
+  agentsTeamStore.loadActiveTeam();
+  agentsTeamStore.loadOfficialAgents();
+  agentsTeamStore.loadMyAgents();
 });
 </script>
 

--- a/src/views/repository/content/Preview.vue
+++ b/src/views/repository/content/Preview.vue
@@ -461,6 +461,10 @@ onMounted(() => {
 
     .footer__message-input {
       width: 100%;
+
+      :deep(.message-input) {
+        padding-right: $unnnic-spacing-xl;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
This PR addresses several issues found in the preview experience:
- Crashes when assigning a newly pushed agent.
- Missing agent identification in logs after an agent is removed from the team.
- Some logs showing without agent identification.
- Input text in the preview being overlapped by the send icon.

### Summary of Changes
- Fixed a crash in the preview when assigning a pushed agent.
- Adjusted the input padding in the Preview component to prevent text from being hidden behind the send icon.
- Added validation for agent names received through `invocationInput` to ensure proper identification in logs.
- Updated PreviewLogs to accept an agents prop, allowing agents to be passed directly instead of relying solely on the AgentsTeam store.
