### PR TITLE
[NEXUS-2993] - Fix Agent Builder 2.0 credentials creation

### DIFF
--- a/src/api/nexusaiAPI.js
+++ b/src/api/nexusaiAPI.js
@@ -180,16 +180,10 @@ export default {
         );
       },
 
-      createCredentials({
-        projectUuid,
-        credentials = {},
-        agent_uuid,
-        is_confidential = true,
-      }) {
+      createCredentials({ projectUuid, credentials = {}, agent_uuid }) {
         return request.$http.post(`api/project/${projectUuid}/credentials`, {
           credentials,
           agent_uuid,
-          is_confidential,
         });
       },
 

--- a/src/components/Brain/AgentsTeam/AssignAgentDrawer.vue
+++ b/src/components/Brain/AgentsTeam/AssignAgentDrawer.vue
@@ -172,18 +172,22 @@ function close() {
 
 async function toggleAgentAssignment() {
   try {
-    const agentHaveCredentialsCreated = props.agent.credentials.some(
-      (credential) => {
-        const [index, type] = tuningsStore.getCredentialIndex(credential.name);
-
-        return tuningsStore.initialCredentials?.[type]?.[index];
-      },
-    );
-
-    if (!agentHaveCredentialsCreated) {
-      await tuningsStore.createCredentials(props.agent.uuid);
-    } else if (credentialsWithoutValue.value.length) {
-      await tuningsStore.saveCredentials();
+    if (credentialsWithoutValue.value.length) {
+      const credentialsToCreate = credentialsWithoutValue.value.map(
+        (credential) => {
+          const [index, type] = tuningsStore.getCredentialIndex(
+            credential.name,
+          );
+          return {
+            ...credential,
+            value: tuningsStore.credentials.data?.[type]?.[index]?.value,
+          };
+        },
+      );
+      await tuningsStore.createCredentials(
+        props.agent.uuid,
+        credentialsToCreate,
+      );
     }
 
     emit('assign');

--- a/src/components/Brain/AgentsTeam/__tests__/AssignAgentDrawer.spec.js
+++ b/src/components/Brain/AgentsTeam/__tests__/AssignAgentDrawer.spec.js
@@ -191,13 +191,21 @@ describe('AssignAgentDrawer.vue', () => {
 
       expect(tuningsStore.createCredentials).toHaveBeenCalledWith(
         mockAgent.uuid,
+        [
+          {
+            name: 'API_KEY',
+            value: '',
+            label: 'API Key',
+            placeholder: 'Enter API key',
+          },
+          {
+            label: 'Base URL',
+            name: 'BASE_URL',
+            placeholder: 'Enter base URL',
+            value: 'https://example.com',
+          },
+        ],
       );
-    });
-
-    it('should call saveCredentials when credentials are not filled', async () => {
-      wrapper.vm.toggleAgentAssignment();
-
-      expect(tuningsStore.saveCredentials).toHaveBeenCalled();
     });
 
     it('should emit assign when credentials are filled', async () => {
@@ -211,7 +219,7 @@ describe('AssignAgentDrawer.vue', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
 
-      tuningsStore.saveCredentials.mockRejectedValue(new Error('Error'));
+      tuningsStore.createCredentials.mockRejectedValue(new Error('Error'));
 
       await wrapper.vm.toggleAgentAssignment();
 

--- a/src/store/Tunings.js
+++ b/src/store/Tunings.js
@@ -236,13 +236,13 @@ export const useTuningsStore = defineStore('Tunings', () => {
     }
   }
 
-  async function createCredentials(agentUuid) {
+  async function createCredentials(agentUuid, credentialsToCreate) {
     try {
       credentials.value.status = 'loading';
 
       await nexusaiAPI.router.tunings.createCredentials({
         projectUuid: connectProjectUuid.value,
-        credentials: credentials.value.data.officialAgents,
+        credentials: credentialsToCreate,
         agent_uuid: agentUuid,
       });
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Credentials were not being created when there was already another agent assigned to the project.

### Summary of Changes
- Removed unnecessary parameter from `/credentials` `POST`
- Adjusted the logic and call for creating credentials and adjusted the tests for this new logic.
