### PR TITLE
[NEXUS-3007] - Fix Supervisor 2.0 conversations params

### DIFF
--- a/src/__tests__/api/nexus/Supervisor.spec.js
+++ b/src/__tests__/api/nexus/Supervisor.spec.js
@@ -314,18 +314,16 @@ describe('Supervisor.js', () => {
 
       const projectUuid = 'project-123';
       const start = '2023-01-01';
-      const end = '2023-01-31';
       const urn = 'tel:+123456789';
 
       const result = await Supervisor.conversations.getById({
         projectUuid,
         start,
-        end,
         urn,
       });
 
       expect(nexusRequest.$http.get).toHaveBeenCalledWith(
-        `/api/${projectUuid}/conversations/?start=2023-01-01&end=2023-01-31&contact_urn=tel%3A%2B123456789`,
+        `/api/${projectUuid}/conversations/?start=2023-01-01&contact_urn=tel%3A%2B123456789`,
       );
       expect(result).toEqual(mockConversationResponse.data);
       expect(result.results[0].contact.urn).toBe('tel:+123456789');
@@ -339,7 +337,6 @@ describe('Supervisor.js', () => {
 
       const projectUuid = 'project-123';
       const start = '2023-01-01';
-      const end = '2023-01-31';
       const urn = 'tel:+123456789';
       const next =
         'https://api.example.com/api/project-123/conversations/?page=1';
@@ -347,7 +344,6 @@ describe('Supervisor.js', () => {
       const result = await Supervisor.conversations.getById({
         projectUuid,
         start,
-        end,
         urn,
         next,
       });
@@ -365,14 +361,12 @@ describe('Supervisor.js', () => {
 
       const projectUuid = 'project-123';
       const start = '2023-01-01';
-      const end = '2023-01-31';
       const urn = 'tel:+123456789';
 
       await expect(
         Supervisor.conversations.getById({
           projectUuid,
           start,
-          end,
           urn,
         }),
       ).rejects.toThrow('API Error');

--- a/src/api/nexus/Supervisor.js
+++ b/src/api/nexus/Supervisor.js
@@ -27,10 +27,9 @@ export const Supervisor = {
       return data;
     },
 
-    async getById({ projectUuid, start, end, urn, next }) {
+    async getById({ projectUuid, start, urn, next }) {
       const params = {
         start,
-        end,
         contact_urn: urn,
       };
 

--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -64,12 +64,15 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
 
   async function loadConversations(page = 1) {
     conversations.status = 'loading';
+
+    const formatDateParam = (date) => format(parseISO(date), 'dd-MM-yyyy');
+
     try {
       const response = await supervisorApi.conversations.list({
         projectUuid: projectUuid.value,
         page,
-        start: format(parseISO(filters.start), 'dd-MM-yyyy'),
-        end: format(parseISO(filters.end), 'dd-MM-yyyy'),
+        start: formatDateParam(filters.start),
+        end: formatDateParam(filters.end),
         search: filters.search,
         type: filters.type,
       });
@@ -91,12 +94,9 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     try {
       selectedConversation.value.data.status = 'loading';
 
-      const formatDateParam = (date) => format(parseISO(date), 'dd-MM-yyyy');
-
       const params = {
         projectUuid: projectUuid.value,
-        start: formatDateParam(filters.start),
-        end: formatDateParam(filters.end),
+        start: selectedConversation.value.created_on,
         urn: selectedConversation.value.urn,
         next: next ? selectedConversation.value.data.next : null,
       };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The Supervisor 2.0 conversations endpoint parameters needed to be changed to follow the new API standard.

### Summary of Changes
Removed unused 'end' parameter from getById and streamline date formatting in loadConversations and adjusted tests to works with this logic.
