### PR TITLE
[NEXUS-3106] - Agent Builder 2.0 preview messages via websocket

### DIFF
--- a/src/websocket/listeners/index.js
+++ b/src/websocket/listeners/index.js
@@ -3,10 +3,21 @@ import previewListener from './preview';
 
 export default ({ ws, type = 'monitoring' }) => {
   const createListener = (callback) => (payload) => callback(payload);
+  const createTypedListener = (expectedType, handler) => (message) => {
+    if (message.type === expectedType) {
+      handler(message);
+    }
+  };
 
   if (type === 'monitoring') {
     ws.on('ws', createListener(monitoringListener.create));
-  } else if (type === 'preview') {
-    ws.on('trace_update', createListener(previewListener.addLog));
+  }
+
+  if (type === 'preview') {
+    ws.on(
+      'trace_update',
+      createTypedListener('trace_update', previewListener.addLog),
+    );
+    ws.on('preview', createTypedListener('preview', previewListener.update));
   }
 };

--- a/src/websocket/listeners/index.js
+++ b/src/websocket/listeners/index.js
@@ -14,10 +14,7 @@ export default ({ ws, type = 'monitoring' }) => {
   }
 
   if (type === 'preview') {
-    ws.on(
-      'trace_update',
-      createTypedListener('trace_update', previewListener.addLog),
-    );
+    ws.on('trace_update', createListener(previewListener.addLog));
     ws.on('preview', createTypedListener('preview', previewListener.update));
   }
 };

--- a/src/websocket/listeners/preview/index.js
+++ b/src/websocket/listeners/preview/index.js
@@ -1,5 +1,7 @@
 import addLog from './addLog';
+import update from './update';
 
 export default {
   addLog,
+  update,
 };

--- a/src/websocket/listeners/preview/update.js
+++ b/src/websocket/listeners/preview/update.js
@@ -1,0 +1,31 @@
+import { useFlowPreviewStore } from '@/store/FlowPreview';
+import i18n from '@/utils/plugins/i18n';
+
+export default (message) => {
+  const flowPreviewStore = useFlowPreviewStore();
+
+  const lastMessage = flowPreviewStore.messages
+    .filter((msg) => msg.type === 'answer')
+    .at(-1);
+
+  let answerToTreat = lastMessage;
+
+  if (lastMessage?.status !== 'loading') {
+    const answer = {
+      type: 'answer',
+      text: '',
+      status: 'loading',
+      question_uuid: null,
+      feedback: {
+        value: null,
+        reason: null,
+      },
+    };
+    flowPreviewStore.addMessage(answer);
+    answerToTreat = answer;
+  }
+
+  flowPreviewStore.treatAnswerResponse(answerToTreat, message.content, {
+    fallbackMessage: i18n.global.t('quick_test.unable_to_find_an_answer'),
+  });
+};


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
To include more than one answer per question in the Agent Builder 2.0 preview

### Summary of Changes
Added preview message listener on websocket connection and integration of responses based on that.
