### PR TITLE
[NEXUS-3185] - Remove 'mailto:' prefix from email links in preview

### DIFF
--- a/src/components/Markdown.vue
+++ b/src/components/Markdown.vue
@@ -27,6 +27,9 @@ export default {
         useNewRenderer: true,
         renderer: {
           link(token) {
+            if (token.includes('mailto:')) {
+              return token.replace('mailto:', '');
+            }
             return `<a target="_blank" href="${token.href || token}">${token.text || token}</a>`;
           },
         },

--- a/src/components/Markdown.vue
+++ b/src/components/Markdown.vue
@@ -27,7 +27,7 @@ export default {
         useNewRenderer: true,
         renderer: {
           link(token) {
-            if (token.includes('mailto:')) {
+            if (typeof token === 'string' && token.includes('mailto:')) {
               return token.replace('mailto:', '');
             }
             return `<a target="_blank" href="${token.href || token}">${token.text || token}</a>`;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
To better the UX, `mailto:` prefix and link are been removed from preview.

### Summary of Changes
Remove 'mailto:' prefix from email links in markdown renderer
