### PR TITLE
[NEXUS-3292] - Fix locales pt_br

### DIFF
--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -242,6 +242,8 @@
         "success_assign_alert": "{agent} atribuído ao time com sucesso",
         "success_unassign_alert": "{agent} removido do time com sucesso",
         "error_alert": "Erro ao tentar atualizar o time",
+        "official": "Oficial",
+        "custom": "Personalizado",
         "remove_agent": "Remover agente"
       },
       "drawer": {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The `pt_br` translations file was missing two translations.

### Summary of Changes
Added `official` and `custom` fields to `pt_br` translations
