### PR TITLE
[NEXUS-3284] - Supervisor formats whatsapp URN

### DIFF
--- a/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue
@@ -9,7 +9,7 @@
       size="body-gt"
       weight="bold"
     >
-      {{ urn }}
+      {{ formattedUrn }}
     </UnnnicIntelligenceText>
     <UnnnicIntelligenceText
       data-testid="conversation-last-message"
@@ -23,7 +23,10 @@
     </UnnnicIntelligenceText>
   </section>
 </template>
+
 <script setup>
+import { computed } from 'vue';
+
 const props = defineProps({
   urn: {
     type: String,
@@ -34,6 +37,33 @@ const props = defineProps({
     required: true,
   },
 });
+
+function formatWhatsappUrn(urn) {
+  const WHATSAPP_PREFIX = 'whatsapp:';
+
+  if (!urn?.startsWith(WHATSAPP_PREFIX)) {
+    return urn;
+  }
+
+  const phoneNumber = urn.replace(WHATSAPP_PREFIX, '');
+
+  if (phoneNumber.length < 10) {
+    return urn;
+  }
+
+  const ddi = phoneNumber.substring(0, 2);
+  const ddd = phoneNumber.substring(2, 4);
+  const number = phoneNumber.substring(4);
+
+  const formattedNumber =
+    number.length === 9
+      ? number.replace(/(\d{5})(\d{4})/, '$1-$2') // 99999-9999
+      : number.replace(/(\d{4})(\d{4})/, '$1-$2'); // 9999-9999
+
+  return `+${ddi} (${ddd}) ${formattedNumber}`;
+}
+
+const formattedUrn = computed(() => formatWhatsappUrn(props.urn));
 </script>
 
 <style scoped lang="scss">

--- a/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/__tests__/ConversationInfos.spec.js
+++ b/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/__tests__/ConversationInfos.spec.js
@@ -1,3 +1,4 @@
+import { expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 
 import ConversationInfos from '@/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue';
@@ -32,5 +33,83 @@ describe('ConversationInfos.vue', () => {
 
   it('displays the last message correctly', () => {
     expect(conversationsLastMessage().text()).toBe(mockLastMessage);
+  });
+
+  describe('formatWhatsAppUrn Function', () => {
+    const validWhatsAppFormats = [
+      {
+        input: 'whatsapp:5511999887766',
+        expected: '+55 (11) 99988-7766',
+        description: '9-digit mobile number',
+      },
+      {
+        input: 'whatsapp:551188776655',
+        expected: '+55 (11) 8877-6655',
+        description: '8-digit landline number',
+      },
+    ];
+
+    validWhatsAppFormats.forEach(({ input, expected, description }) => {
+      it(`should format ${description} correctly`, async () => {
+        await wrapper.setProps({ urn: input });
+
+        expect(conversationsUrn().text()).toBe(expected);
+      });
+    });
+
+    const nonWhatsAppUrns = [
+      {
+        input: 'telegram:123456789',
+        description: 'telegram URN',
+      },
+      {
+        input: 'mailto:user@example.com',
+        description: 'email URN',
+      },
+      {
+        input: 'simple-urn-123',
+        description: 'plain text URN',
+      },
+    ];
+
+    nonWhatsAppUrns.forEach(({ input, description }) => {
+      it(`should return ${description} unchanged`, async () => {
+        await wrapper.setProps({ urn: input });
+
+        expect(conversationsUrn().text()).toBe(input);
+      });
+    });
+
+    const edgeCases = [
+      {
+        input: 'whatsapp:123',
+        expected: 'whatsapp:123',
+        description: 'phone number too short',
+      },
+      {
+        input: 'whatsapp:123456789',
+        expected: 'whatsapp:123456789',
+        description:
+          'phone number with exactly 9 digits (less than DDI+DDD+number)',
+      },
+      {
+        input: 'whatsapp:',
+        expected: 'whatsapp:',
+        description: 'WhatsApp URN with only prefix',
+      },
+      {
+        input: '',
+        expected: '',
+        description: 'empty string URN',
+      },
+    ];
+
+    edgeCases.forEach(({ input, expected, description }) => {
+      it(`should handle ${description} gracefully`, async () => {
+        await wrapper.setProps({ urn: input });
+
+        expect(conversationsUrn().text()).toBe(expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The standardization of Whatsapp contact URNs in the Supervisor was requested for the format `+DDI (DDD) 00000-00000`

### Summary of Changes
- Supervisor WhatsApp URN formatting and add unit tests

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/20b6bcfd-5405-43c5-afd5-6a2c02f813d2)
