### PR TITLE
hotfix: Update Supervidor WhatsApp URN validation to require 12 digits

### DIFF
--- a/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue
@@ -47,7 +47,7 @@ function formatWhatsappUrn(urn) {
 
   const phoneNumber = urn.replace(WHATSAPP_PREFIX, '');
 
-  if (phoneNumber.length < 10) {
+  if (phoneNumber.length < 12) {
     return urn;
   }
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Some numbers with different country codes from Brazil were being formatted as if they were.