### PR TITLE
[NEXUS-3564] - Log processing handling trace types

### DIFF
--- a/src/utils/previewLogs.js
+++ b/src/utils/previewLogs.js
@@ -164,7 +164,7 @@ function getLogConfig({ trace, config }) {
       category: 'tool',
       icon: 'build',
     },
-    config?.agentName !== 'manager'
+    config?.agentName && config?.agentName !== 'manager'
       ? {
           type: 'sending_response',
           key: finalResponse,


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
It was necessary to implement trace type handling to support the format already sent by the backend. This way, processing now recognizes and handles traces arriving with the previously defined type.

### Summary of Changes
Added expected types in the `previewLogs` utility to map and process traces according to their respective types.
