### PR TITLE
[NEXUS-3736] Fix Supervisor pagination

### DIFF
--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -29,15 +29,15 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
   let conversationsAbortController = null;
 
   const filters = reactive({
-    start: route.query.start || thisMonth,
-    end: route.query.end || today,
-    search: route.query.search || '',
-    status: route.query.status || [],
-    csat: route.query.csat || [],
-    topics: route.query.topics || [],
+    start: route?.query.start || thisMonth,
+    end: route?.query.end || today,
+    search: route?.query.search || '',
+    status: route?.query.status || [],
+    csat: route?.query.csat || [],
+    topics: route?.query.topics || [],
   });
 
-  const queryConversationUuid = ref(route.query.uuid || '');
+  const queryConversationUuid = ref(route?.query.uuid || '');
 
   async function loadConversations(page = 1) {
     if (conversationsAbortController) {

--- a/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/index.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/index.vue
@@ -106,11 +106,8 @@ watch(
 
     if (!hasFiltersChanged) return;
 
-    if (pagination.value.page === 1) {
-      supervisorStore.loadConversations();
-    } else {
-      pagination.value.page = 1;
-    }
+    pagination.value.page = 1;
+    supervisorStore.loadConversations();
   },
   { immediate: true, deep: true },
 );

--- a/src/views/AgentBuilder/Supervisor/SupervisorConversations/__tests__/index.spec.js
+++ b/src/views/AgentBuilder/Supervisor/SupervisorConversations/__tests__/index.spec.js
@@ -1,16 +1,34 @@
 import { shallowMount } from '@vue/test-utils';
 import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
 
 import SupervisorConversations from '../index.vue';
 
 describe('SupervisorConversations', () => {
   let wrapper;
+  let pinia;
 
   const conversationsTable = () =>
     wrapper.find('[data-testid="conversations-table"]');
 
   beforeEach(() => {
-    wrapper = shallowMount(SupervisorConversations);
+    pinia = createTestingPinia({
+      initialState: {
+        Supervisor: {
+          conversations: {
+            data: {
+              results: [],
+            },
+          },
+        },
+      },
+    });
+
+    wrapper = shallowMount(SupervisorConversations, {
+      global: {
+        plugins: [pinia],
+      },
+    });
   });
 
   describe('Component rendering', () => {

--- a/src/views/AgentBuilder/Supervisor/SupervisorConversations/index.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorConversations/index.vue
@@ -1,5 +1,7 @@
 <template>
-  <section class="conversations">
+  <section
+    :class="['conversations', { 'conversations--empty': !hasConversations }]"
+  >
     <SupervisorFilters data-testid="supervisor-filters" />
 
     <ConversationsTable
@@ -10,10 +12,17 @@
 </template>
 
 <script setup>
-import { ref, defineExpose } from 'vue';
+import { ref, defineExpose, computed } from 'vue';
 
 import SupervisorFilters from '../SupervisorFilters/index.vue';
 import ConversationsTable from './ConversationsTable/index.vue';
+import { useSupervisorStore } from '@/store/Supervisor';
+
+const supervisorStore = useSupervisorStore();
+
+const hasConversations = computed(
+  () => supervisorStore.conversations.data.results.length > 0,
+);
 
 const conversationsTable = ref(null);
 
@@ -24,11 +33,13 @@ defineExpose({
 
 <style scoped lang="scss">
 .conversations {
-  height: 100%;
-
   display: grid;
   grid-template-rows: auto 1fr;
   gap: $unnnic-spacing-sm;
   align-items: start;
+
+  &--empty {
+    height: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The Supervisor's scrolling page wasn't working visually, and the first filter request after paging wasn't being invoked.

### Summary of Changes
- Fixed the filter API call logic to be invoked whenever the filter changes.
- Adjusted the visuals so that conversations scroll.
