### PR TITLE
[NEXUS-3703] - Profile at sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/vue": "^8.9.2",
         "@tsparticles/slim": "^3.8.1",
         "@tsparticles/vue3": "^3.0.1",
-        "@weni/unnnic-system": "3.1.2",
+        "@weni/unnnic-system": "3.2.1",
         "axios": "^1.6.8",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
@@ -281,6 +281,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -504,11 +513,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@emoji-mart/data": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
-      "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -3610,13 +3614,12 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.1.2.tgz",
-      "integrity": "sha512-6fWMtF4oeXjRPj88nMpFEheCMu8Te2YZ9wuLXc7AFpVSwwRT+sw6bTQMWUMb8TCGO008+SbITTadbn14zrkj5w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.2.1.tgz",
+      "integrity": "sha512-HetFmyvwrbbwNl0kRbymmEPKT/8nup6EyfIiJ9ElPLJCt3W5j1MSx2u3hMpQ1NNFRx6/1TxW8XObIQtmumxWlQ==",
       "dependencies": {
-        "@emoji-mart/data": "^1.1.2",
         "@vueuse/components": "^10.4.1",
-        "emoji-mart": "^5.5.2",
+        "emoji-mart-vue-fast": "^15.0.5",
         "lodash": "^4.17.21",
         "mime": "^4.0.1",
         "mitt": "^3.0.1",
@@ -5146,10 +5149,18 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.166.tgz",
       "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw=="
     },
-    "node_modules/emoji-mart": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
-      "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow=="
+    "node_modules/emoji-mart-vue-fast": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.5.tgz",
+      "integrity": "sha512-wnxLor8ggpqshoOPwIc33MdOC3A1XFeDLgUwYLPtNPL8VeAtXJAVrnFq1CN5PeCYAFoLo4IufHQZ9CfHD4IZiw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "core-js": "^3.23.5"
+      },
+      "peerDependencies": {
+        "vue": ">2.0.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@sentry/vue": "^8.9.2",
     "@tsparticles/slim": "^3.8.1",
     "@tsparticles/vue3": "^3.0.1",
-    "@weni/unnnic-system": "3.1.2",
+    "@weni/unnnic-system": "3.2.1",
     "axios": "^1.6.8",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",

--- a/src/components/AgentBuilder/Header.vue
+++ b/src/components/AgentBuilder/Header.vue
@@ -19,7 +19,7 @@
         color="neutral-darkest"
         data-testid="agent-builder-header-title"
       >
-        {{ currentBrainRoute?.title }}
+        {{ currentView?.title }}
       </UnnnicIntelligenceText>
       <UnnnicIntelligenceText
         tag="h2"
@@ -28,11 +28,11 @@
         color="neutral-cloudy"
         data-testid="agent-builder-header-description"
       >
-        {{ currentBrainRoute?.description }}
+        {{ currentView?.description }}
 
         <SupervisorHeaderDetails
           v-if="
-            currentBrainRoute.page === 'supervisor' &&
+            currentView.page === 'supervisor' &&
             featureFlagsStore.flags.newSupervisor
           "
         />
@@ -53,7 +53,7 @@
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 
-import useBrainRoutes from '@/composables/useBrainRoutes';
+import useAgentBuilderViews from '@/composables/useAgentBuilderViews';
 
 import SupervisorHeaderDetails from './Supervisor/SupervisorHeaderDetails.vue';
 
@@ -83,11 +83,9 @@ const props = defineProps({
 
 const featureFlagsStore = useFeatureFlagsStore();
 
-const currentBrainRoute = computed(() => {
-  const brainRoutes = useBrainRoutes();
-  return (
-    brainRoutes.value.find((e) => e.page === route.name) || brainRoutes.value[0]
-  );
+const currentView = computed(() => {
+  const views = useAgentBuilderViews();
+  return views.value.find((e) => e.page === route.name) || views.value[0];
 });
 </script>
 

--- a/src/components/AgentBuilder/Sidebar.vue
+++ b/src/components/AgentBuilder/Sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <nav
     :class="['sidebar', { collapsed: isCollapsed }]"
     @mouseover="handleMouseOver"
     @mouseleave="handleMouseLeave"
@@ -16,7 +16,7 @@
     <section v-if="isSideBarVisible">
       <SidebarMenu data-test="side-bar-menu">
         <SideBarItem
-          v-for="nav in brainRoutes"
+          v-for="nav in views"
           :key="nav.page"
           :text="nav.title"
           :icon="nav.icon"
@@ -28,22 +28,22 @@
         />
       </SidebarMenu>
     </section>
-  </div>
+  </nav>
 </template>
 
 <script setup>
 import { ref, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import useBrainRoutes from '@/composables/useBrainRoutes';
+import useAgentBuilderViews from '@/composables/useAgentBuilderViews';
 import SideBarItem from '../Sidebar/SideBarItem.vue';
 import SidebarMenu from '../Sidebar/SidebarMenu.vue';
 
 const route = useRoute();
 const router = useRouter();
-const brainRoutes = useBrainRoutes();
+const views = useAgentBuilderViews();
 
 const activeNav = computed(() => {
-  return brainRoutes.value.find((e) => e.page === route.name)?.page;
+  return views.value.find((e) => e.page === route.name)?.page;
 });
 
 const isCollapsed = ref(false);

--- a/src/components/AgentBuilder/Sidebar.vue
+++ b/src/components/AgentBuilder/Sidebar.vue
@@ -1,0 +1,177 @@
+<template>
+  <div
+    :class="['sidebar', { collapsed: isCollapsed }]"
+    @mouseover="handleMouseOver"
+    @mouseleave="handleMouseLeave"
+  >
+    <UnnnicButton
+      v-if="isCollapsed || isHoveringSidebar"
+      class="floating-button"
+      :iconCenter="isCollapsed ? 'arrow_forward_ios' : 'arrow_back_ios_new'"
+      type="secondary"
+      data-test="floating-btn"
+      @click="handleButtonClick"
+    />
+
+    <section v-if="isSideBarVisible">
+      <SidebarMenu data-test="side-bar-menu">
+        <SideBarItem
+          v-for="nav in brainRoutes"
+          :key="nav.page"
+          :text="nav.title"
+          :icon="nav.icon"
+          :active="nav.page === activeNav"
+          :iconFilled="nav.page === activeNav"
+          :tag="nav.tag"
+          data-test="nav-router"
+          @click="onNavChange(nav.page)"
+        />
+      </SidebarMenu>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import useBrainRoutes from '@/composables/useBrainRoutes';
+import SideBarItem from '../Sidebar/SideBarItem.vue';
+import SidebarMenu from '../Sidebar/SidebarMenu.vue';
+
+const route = useRoute();
+const router = useRouter();
+const brainRoutes = useBrainRoutes();
+
+const activeNav = computed(() => {
+  return brainRoutes.value.find((e) => e.page === route.name)?.page;
+});
+
+const isCollapsed = ref(false);
+const isSideBarVisible = ref(true);
+const isHoveringSidebar = ref(false);
+
+const onNavChange = (pageName) => {
+  if (route.name !== pageName) {
+    router.push({ name: pageName });
+  }
+};
+
+const handleButtonClick = () => {
+  if (isCollapsed.value) {
+    isCollapsed.value = false;
+    setTimeout(() => {
+      isSideBarVisible.value = true;
+    }, 300);
+    return;
+  }
+
+  isCollapsed.value = true;
+  isSideBarVisible.value = false;
+};
+
+const handleMouseOver = () => {
+  if (!isCollapsed.value) {
+    isHoveringSidebar.value = true;
+  }
+};
+
+const handleMouseLeave = () => {
+  isHoveringSidebar.value = false;
+};
+</script>
+
+<style lang="scss" scoped>
+.sidebar {
+  border-style: solid;
+  border-color: $unnnic-color-neutral-soft;
+  border-width: 0 0 0 $unnnic-border-width-thinner;
+  padding: $unnnic-spacing-sm;
+  width: 182px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  transition:
+    width 0.5s ease,
+    padding 0.5s ease;
+
+  &.collapsed {
+    padding-left: 18px;
+    padding-right: 0;
+    width: 0;
+  }
+
+  .floating-button {
+    position: absolute;
+    top: 27px;
+    left: 100%;
+    transform: translateX(-50%);
+    border-radius: $unnnic-border-radius-pill;
+    background: $unnnic-color-neutral-white;
+    border: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+    padding: 0;
+    transition: opacity 0.3s ease;
+
+    &:hover:enabled {
+      background: none;
+    }
+  }
+
+  .unnnic-side-bar {
+    transition:
+      opacity 0.5s ease,
+      transform 0.5s ease;
+    transform-origin: left center;
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  &.collapsed .unnnic-side-bar {
+    opacity: 0;
+    transform: translateX(-100%);
+    pointer-events: none;
+  }
+
+  :deep(.unnnic-side-bar-menu__title) {
+    margin: 0 0 $unnnic-spacing-nano;
+  }
+
+  :deep(.unnnic-button--icon-on-center.unnnic-button--size-large) {
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: 1px solid $unnnic-color-neutral-clean;
+  }
+
+  :deep(.material-symbols-rounded.unnnic-icon-size--md) {
+    font-size: 10px;
+    color: $unnnic-color-neutral-clean;
+  }
+
+  :deep(.unnnic-side-bar-item) {
+    color: $unnnic-color-neutral-cloudy;
+
+    &:hover {
+      background-color: $unnnic-color-background-sky;
+    }
+
+    div {
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  :deep(.unnnic-side-bar-item--active) {
+    background-color: $unnnic-color-background-sky;
+  }
+
+  :deep(.unnnic-icon-size--sm) {
+    font-size: $unnnic-font-size-title-sm;
+  }
+}
+</style>

--- a/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
+++ b/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
@@ -1,7 +1,19 @@
 <template>
-  <section class="sidebar-header">
-    <h1 class="sidebar-header__title">Agent Name</h1>
-    <p class="sidebar-header__description">
+  <section
+    class="sidebar-header"
+    data-testid="sidebar-header"
+  >
+    <h1
+      class="sidebar-header__title"
+      data-testid="sidebar-header-title"
+    >
+      <!-- TODO: Be this hardcoded name dynamic based on the agent name -->
+      Agent Name
+    </h1>
+    <p
+      class="sidebar-header__description"
+      data-testid="sidebar-header-description"
+    >
       {{ $t('profile.edit_manager_profile') }}
     </p>
   </section>

--- a/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
+++ b/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
@@ -1,27 +1,45 @@
 <template>
   <section
-    class="sidebar-header"
+    :class="['sidebar-header', { 'sidebar-header--loading': isLoading }]"
     data-testid="sidebar-header"
   >
-    <h1
-      class="sidebar-header__title"
-      data-testid="sidebar-header-title"
-    >
-      {{ profileStore.name.old }}
-    </h1>
-    <p
-      class="sidebar-header__description"
-      data-testid="sidebar-header-description"
-    >
-      {{ $t('profile.edit_manager_profile') }}
-    </p>
+    <template v-if="isLoading">
+      <UnnnicSkeletonLoading
+        tag="div"
+        width="100%"
+        height="19px"
+        data-testid="sidebar-header-skeleton"
+      />
+      <UnnnicSkeletonLoading
+        tag="div"
+        width="100%"
+        height="17px"
+        data-testid="sidebar-header-skeleton"
+      />
+    </template>
+    <template v-else>
+      <h1
+        class="sidebar-header__title"
+        data-testid="sidebar-header-title"
+      >
+        {{ profileStore.name.old }}
+      </h1>
+      <p
+        class="sidebar-header__description"
+        data-testid="sidebar-header-description"
+      >
+        {{ $t('profile.edit_manager_profile') }}
+      </p>
+    </template>
   </section>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { useProfileStore } from '@/store/Profile';
 
 const profileStore = useProfileStore();
+const isLoading = computed(() => profileStore.status === 'loading');
 </script>
 
 <style lang="scss" scoped>
@@ -33,9 +51,13 @@ const profileStore = useProfileStore();
   flex-direction: column;
   justify-content: space-between;
 
-  &:hover {
+  &:hover:not(&--loading) {
     cursor: pointer;
     background-color: $unnnic-color-bg-soft;
+  }
+
+  &--loading {
+    gap: $unnnic-spacing-nano;
   }
 
   &__title {

--- a/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
+++ b/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
@@ -18,7 +18,11 @@
   </section>
 </template>
 
-<script setup></script>
+<script setup>
+import { useProfileStore } from '@/store/Profile';
+
+const profileStore = useProfileStore();
+</script>
 
 <style lang="scss" scoped>
 .sidebar-header {

--- a/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
+++ b/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
@@ -1,0 +1,43 @@
+<template>
+  <section class="sidebar-header">
+    <h1 class="sidebar-header__title">Agent Name</h1>
+    <p class="sidebar-header__description">
+      {{ $t('profile.edit_manager_profile') }}
+    </p>
+  </section>
+</template>
+
+<script setup></script>
+
+<style lang="scss" scoped>
+.sidebar-header {
+  border-bottom: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  padding-bottom: $unnnic-spacing-sm;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  &:hover {
+    cursor: pointer;
+    background-color: $unnnic-color-bg-soft;
+  }
+
+  &__title {
+    margin: 0;
+
+    color: $unnnic-color-neutral-darkest;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-body-gt;
+    font-weight: $unnnic-font-weight-bold;
+    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+  }
+
+  &__description {
+    color: $unnnic-color-neutral-clean;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-body-md;
+    line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+  }
+}
+</style>

--- a/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
+++ b/src/components/AgentBuilder/Sidebar/SidebarHeader.vue
@@ -7,8 +7,7 @@
       class="sidebar-header__title"
       data-testid="sidebar-header-title"
     >
-      <!-- TODO: Be this hardcoded name dynamic based on the agent name -->
-      Agent Name
+      {{ profileStore.name.old }}
     </h1>
     <p
       class="sidebar-header__description"

--- a/src/components/AgentBuilder/Sidebar/__tests__/SidebarHeader.spec.js
+++ b/src/components/AgentBuilder/Sidebar/__tests__/SidebarHeader.spec.js
@@ -1,10 +1,17 @@
 import { mount } from '@vue/test-utils';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SidebarHeader from '../SidebarHeader.vue';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import { useProfileStore } from '@/store/Profile';
 import i18n from '@/utils/plugins/i18n';
+
+import SidebarHeader from '../SidebarHeader.vue';
+
+const pinia = createTestingPinia();
 
 describe('SidebarHeader.vue', () => {
   let wrapper;
+  let profileStore;
 
   const elements = {
     sidebarHeader: '[data-testid="sidebar-header"]',
@@ -15,9 +22,11 @@ describe('SidebarHeader.vue', () => {
   beforeEach(() => {
     wrapper = mount(SidebarHeader, {
       global: {
-        plugins: [i18n],
+        plugins: [i18n, pinia],
       },
     });
+
+    profileStore = useProfileStore();
   });
 
   describe('Component structure', () => {
@@ -45,7 +54,10 @@ describe('SidebarHeader.vue', () => {
 
   describe('Content rendering', () => {
     it('displays the profile agent name in the title', () => {
-      //TODO: Make this test after the agent name is not hardcoded
+      const titleElement = wrapper.find(elements.title);
+      const expectedText = profileStore.name.old;
+
+      expect(titleElement.text()).toBe(expectedText);
     });
 
     it('displays the translated description text', () => {

--- a/src/components/AgentBuilder/Sidebar/__tests__/SidebarHeader.spec.js
+++ b/src/components/AgentBuilder/Sidebar/__tests__/SidebarHeader.spec.js
@@ -1,0 +1,80 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import SidebarHeader from '../SidebarHeader.vue';
+import i18n from '@/utils/plugins/i18n';
+
+describe('SidebarHeader.vue', () => {
+  let wrapper;
+
+  const elements = {
+    sidebarHeader: '[data-testid="sidebar-header"]',
+    title: '[data-testid="sidebar-header-title"]',
+    description: '[data-testid="sidebar-header-description"]',
+  };
+
+  beforeEach(() => {
+    wrapper = mount(SidebarHeader, {
+      global: {
+        plugins: [i18n],
+      },
+    });
+  });
+
+  describe('Component structure', () => {
+    it('renders the main section element', () => {
+      const headerSection = wrapper.find(elements.sidebarHeader);
+
+      expect(headerSection.exists()).toBe(true);
+      expect(headerSection.element.tagName).toBe('SECTION');
+    });
+
+    it('renders the title as an h1 element', () => {
+      const titleElement = wrapper.find(elements.title);
+
+      expect(titleElement.exists()).toBe(true);
+      expect(titleElement.element.tagName).toBe('H1');
+    });
+
+    it('renders the description as a p element', () => {
+      const descriptionElement = wrapper.find(elements.description);
+
+      expect(descriptionElement.exists()).toBe(true);
+      expect(descriptionElement.element.tagName).toBe('P');
+    });
+  });
+
+  describe('Content rendering', () => {
+    it('displays the profile agent name in the title', () => {
+      //TODO: Make this test after the agent name is not hardcoded
+    });
+
+    it('displays the translated description text', () => {
+      const descriptionElement = wrapper.find(elements.description);
+      const expectedText = i18n.global.t('profile.edit_manager_profile');
+
+      expect(descriptionElement.text()).toBe(expectedText);
+    });
+  });
+
+  describe('CSS classes and styling', () => {
+    it('applies the correct CSS class to the main section', () => {
+      const headerSection = wrapper.find(elements.sidebarHeader);
+
+      expect(headerSection.classes()).toContain('sidebar-header');
+    });
+
+    it('applies the correct CSS class to the title', () => {
+      const titleElement = wrapper.find(elements.title);
+
+      expect(titleElement.classes()).toContain('sidebar-header__title');
+    });
+
+    it('applies the correct CSS class to the description', () => {
+      const descriptionElement = wrapper.find(elements.description);
+
+      expect(descriptionElement.classes()).toContain(
+        'sidebar-header__description',
+      );
+    });
+  });
+});

--- a/src/components/AgentBuilder/Sidebar/index.vue
+++ b/src/components/AgentBuilder/Sidebar/index.vue
@@ -14,7 +14,12 @@
     />
 
     <section v-if="isSideBarVisible">
-      <SidebarMenu data-test="side-bar-menu">
+      <SidebarHeader class="sidebar__header" />
+
+      <SidebarMenu
+        class="sidebar__menu"
+        data-test="side-bar-menu"
+      >
         <SideBarItem
           v-for="nav in views"
           :key="nav.page"
@@ -34,9 +39,11 @@
 <script setup>
 import { ref, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
+
 import useAgentBuilderViews from '@/composables/useAgentBuilderViews';
-import SideBarItem from '../Sidebar/SideBarItem.vue';
-import SidebarMenu from '../Sidebar/SidebarMenu.vue';
+import SidebarHeader from './SidebarHeader.vue';
+import SideBarItem from '@/components/Sidebar/SideBarItem.vue';
+import SidebarMenu from '@/components/Sidebar/SidebarMenu.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -82,10 +89,7 @@ const handleMouseLeave = () => {
 
 <style lang="scss" scoped>
 .sidebar {
-  border-style: solid;
-  border-color: $unnnic-color-neutral-soft;
-  border-width: 0 0 0 $unnnic-border-width-thinner;
-  padding: $unnnic-spacing-sm;
+  border-right: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
   width: 182px;
   box-sizing: border-box;
   display: flex;
@@ -99,6 +103,11 @@ const handleMouseLeave = () => {
     padding-left: 18px;
     padding-right: 0;
     width: 0;
+  }
+
+  &__header,
+  &__menu {
+    padding: $unnnic-spacing-sm;
   }
 
   .floating-button {

--- a/src/components/AgentBuilder/__tests__/Header.spec.js
+++ b/src/components/AgentBuilder/__tests__/Header.spec.js
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Header from '../Header.vue';
 import { createTestingPinia } from '@pinia/testing';
 
-vi.mock('@/composables/useBrainRoutes', () => {
+vi.mock('@/composables/useAgentBuilderViews', () => {
   return {
     default: vi.fn(() => {
       return {

--- a/src/composables/__tests__/useAgentBuilderViews.spec.js
+++ b/src/composables/__tests__/useAgentBuilderViews.spec.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import useAgentBuilderViews from '../useAgentBuilderViews';
+import i18n from '@/utils/plugins/i18n';
+
+const { t } = i18n.global;
+
+describe('useAgentBuilderViews', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('composable structure', () => {
+    it('should return a computed property', () => {
+      const result = useAgentBuilderViews();
+
+      expect(result).toBeDefined();
+      expect(result.value).toBeDefined();
+      expect(Array.isArray(result.value)).toBe(true);
+    });
+
+    it('should return an array of view objects', () => {
+      const result = useAgentBuilderViews();
+
+      expect(result.value).toHaveLength(5);
+      result.value.forEach((view) => {
+        expect(view).toHaveProperty('title');
+        expect(view).toHaveProperty('description');
+        expect(view).toHaveProperty('page');
+        expect(view).toHaveProperty('icon');
+      });
+    });
+  });
+
+  describe('view objects structure', () => {
+    let views;
+
+    beforeEach(() => {
+      const result = useAgentBuilderViews();
+      views = result.value;
+    });
+
+    it('should have supervisor view with correct properties', () => {
+      const supervisorView = views.find((view) => view.page === 'supervisor');
+
+      expect(supervisorView).toBeDefined();
+      expect(supervisorView.title).toBe(
+        t('agent_builder.tabs.supervisor.title'),
+      );
+      expect(supervisorView.description).toBe(
+        t('agent_builder.tabs.supervisor.description'),
+      );
+      expect(supervisorView.page).toBe('supervisor');
+      expect(supervisorView.icon).toBe('sms');
+    });
+
+    it('should have instructions view with correct properties', () => {
+      const instructionsView = views.find(
+        (view) => view.page === 'instructions',
+      );
+
+      expect(instructionsView).toBeDefined();
+      expect(instructionsView.title).toBe(
+        t('agent_builder.tabs.instructions.title'),
+      );
+      expect(instructionsView.description).toBe(
+        t('agent_builder.tabs.instructions.description'),
+      );
+      expect(instructionsView.page).toBe('instructions');
+      expect(instructionsView.icon).toBe('format_list_bulleted');
+    });
+
+    it('should have agents view with correct properties', () => {
+      const agentsView = views.find((view) => view.page === 'agents');
+
+      expect(agentsView).toBeDefined();
+      expect(agentsView.title).toBe(t('agent_builder.tabs.agents.title'));
+      expect(agentsView.description).toBe(
+        t('agent_builder.tabs.agents.description'),
+      );
+      expect(agentsView.page).toBe('agents');
+      expect(agentsView.icon).toBe('workspaces');
+    });
+
+    it('should have knowledge view with correct properties', () => {
+      const knowledgeView = views.find((view) => view.page === 'knowledge');
+
+      expect(knowledgeView).toBeDefined();
+      expect(knowledgeView.title).toBe(t('agent_builder.tabs.knowledge.title'));
+      expect(knowledgeView.description).toBe(
+        t('agent_builder.tabs.knowledge.description'),
+      );
+      expect(knowledgeView.page).toBe('knowledge');
+      expect(knowledgeView.icon).toBe('article');
+    });
+
+    it('should have tunings view with correct properties', () => {
+      const tuningsView = views.find((view) => view.page === 'tunings');
+
+      expect(tuningsView).toBeDefined();
+      expect(tuningsView.title).toBe(t('agent_builder.tabs.tunings.title'));
+      expect(tuningsView.description).toBe(
+        t('agent_builder.tabs.tunings.description'),
+      );
+      expect(tuningsView.page).toBe('tunings');
+      expect(tuningsView.icon).toBe('settings');
+    });
+  });
+
+  describe('view order and completeness', () => {
+    it('should return views in the correct order', () => {
+      const result = useAgentBuilderViews();
+      const views = result.value;
+
+      const expectedOrder = [
+        'supervisor',
+        'instructions',
+        'agents',
+        'knowledge',
+        'tunings',
+      ];
+      const actualOrder = views.map((view) => view.page);
+
+      expect(actualOrder).toEqual(expectedOrder);
+    });
+
+    it('should have unique page identifiers', () => {
+      const result = useAgentBuilderViews();
+      const views = result.value;
+
+      const pages = views.map((view) => view.page);
+      const uniquePages = [...new Set(pages)];
+
+      expect(pages).toHaveLength(uniquePages.length);
+    });
+
+    it('should have unique icons for each view', () => {
+      const result = useAgentBuilderViews();
+      const views = result.value;
+
+      const icons = views.map((view) => view.icon);
+      const uniqueIcons = [...new Set(icons)];
+
+      expect(icons).toHaveLength(uniqueIcons.length);
+    });
+
+    it('should have all required properties for each view', () => {
+      const result = useAgentBuilderViews();
+      const views = result.value;
+
+      const requiredProperties = ['title', 'description', 'page', 'icon'];
+
+      views.forEach((view) => {
+        requiredProperties.forEach((prop) => {
+          expect(view).toHaveProperty(prop);
+          expect(view[prop]).toBeTruthy();
+        });
+      });
+    });
+  });
+});

--- a/src/composables/useAgentBuilderViews.js
+++ b/src/composables/useAgentBuilderViews.js
@@ -1,0 +1,39 @@
+import { computed } from 'vue';
+import i18n from '@/utils/plugins/i18n';
+
+export default function useAgentBuilderViews() {
+  const t = (value) => i18n.global.t(value);
+
+  return computed(() => [
+    {
+      title: t('agent_builder.tabs.supervisor.title'),
+      description: t('agent_builder.tabs.supervisor.description'),
+      page: 'supervisor',
+      icon: 'sms',
+    },
+    {
+      title: t('agent_builder.tabs.instructions.title'),
+      description: t('agent_builder.tabs.instructions.description'),
+      page: 'instructions',
+      icon: 'format_list_bulleted',
+    },
+    {
+      title: t('agent_builder.tabs.agents.title'),
+      description: t('agent_builder.tabs.agents.description'),
+      page: 'agents',
+      icon: 'workspaces',
+    },
+    {
+      title: t('agent_builder.tabs.knowledge.title'),
+      description: t('agent_builder.tabs.knowledge.description'),
+      page: 'knowledge',
+      icon: 'article',
+    },
+    {
+      title: t('agent_builder.tabs.tunings.title'),
+      description: t('agent_builder.tabs.tunings.description'),
+      page: 'tunings',
+      icon: 'settings',
+    },
+  ]);
+}

--- a/src/composables/useBrainRoutes.js
+++ b/src/composables/useBrainRoutes.js
@@ -1,92 +1,45 @@
 import { computed } from 'vue';
 import i18n from '@/utils/plugins/i18n';
-import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 export default function useBrainRoutes() {
   const t = (value) => i18n.global.t(value);
-  const featureFlagsStore = useFeatureFlagsStore();
 
-  const isAgentsTeamEnabled = featureFlagsStore.flags.agentsTeam;
-
-  return computed(() => {
-    if (isAgentsTeamEnabled) {
-      return [
-        {
-          title: t('agent_builder.tabs.supervisor.title'),
-          description: t('agent_builder.tabs.supervisor.description'),
-          page: 'supervisor',
-          icon: 'sms',
-        },
-        {
-          title: t('agent_builder.tabs.profile.title'),
-          description: t('agent_builder.tabs.profile.description'),
-          page: 'profile',
-          icon: 'person',
-        },
-        {
-          title: t('agent_builder.tabs.instructions.title'),
-          description: t('agent_builder.tabs.instructions.description'),
-          page: 'instructions',
-          icon: 'format_list_bulleted',
-        },
-        {
-          title: t('agent_builder.tabs.agents.title'),
-          description: t('agent_builder.tabs.agents.description'),
-          page: 'agents',
-          icon: 'workspaces',
-        },
-        {
-          title: t('agent_builder.tabs.knowledge.title'),
-          description: t('agent_builder.tabs.knowledge.description'),
-          page: 'knowledge',
-          icon: 'article',
-        },
-        {
-          title: t('agent_builder.tabs.tunings.title'),
-          description: t('agent_builder.tabs.tunings.description'),
-          page: 'tunings',
-          icon: 'settings',
-        },
-      ];
-    }
-
-    return [
-      {
-        title: t('router.tabs.monitoring'),
-        description: t('router.monitoring.description'),
-        page: 'router-monitoring',
-        icon: 'bar_chart',
-        preview: false,
-        tag: t('new'),
-      },
-      {
-        title: t('router.tabs.profile'),
-        description: t('profile.description'),
-        page: 'router-profile',
-        icon: 'person',
-        preview: true,
-      },
-      {
-        title: t('router.tabs.content'),
-        description: t('content_bases.description'),
-        page: 'router-content',
-        icon: 'article',
-        preview: true,
-      },
-      {
-        title: t('router.tabs.actions'),
-        description: t('router.actions.description'),
-        page: 'router-actions',
-        icon: 'bolt',
-        preview: true,
-      },
-      {
-        title: t('router.tabs.tunings'),
-        description: t('router.tunings.description'),
-        page: 'router-tunings',
-        icon: 'settings',
-        preview: true,
-      },
-    ];
-  });
+  return computed(() => [
+    {
+      title: t('router.tabs.monitoring'),
+      description: t('router.monitoring.description'),
+      page: 'router-monitoring',
+      icon: 'bar_chart',
+      preview: false,
+      tag: t('new'),
+    },
+    {
+      title: t('router.tabs.profile'),
+      description: t('profile.description'),
+      page: 'router-profile',
+      icon: 'person',
+      preview: true,
+    },
+    {
+      title: t('router.tabs.content'),
+      description: t('content_bases.description'),
+      page: 'router-content',
+      icon: 'article',
+      preview: true,
+    },
+    {
+      title: t('router.tabs.actions'),
+      description: t('router.actions.description'),
+      page: 'router-actions',
+      icon: 'bolt',
+      preview: true,
+    },
+    {
+      title: t('router.tabs.tunings'),
+      description: t('router.tunings.description'),
+      page: 'router-tunings',
+      icon: 'settings',
+      preview: true,
+    },
+  ]);
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,10 +67,6 @@
         "title": "Supervisor",
         "description": "Review and analyze conversations between agents and customers."
       },
-      "profile": {
-        "title": "Profile",
-        "description": "Customize the agent's basic information and behavior"
-      },
       "instructions": {
         "title": "Instructions",
         "description": "Write quick rules to shape the agent’s behavior"
@@ -1994,6 +1990,7 @@
     }
   },
   "profile": {
+    "edit_manager_profile": "Edit Manager profile",
     "description": "Customize the basic information and behavior of the agent",
     "save_btn": "Save changes",
     "invalid_field": "Required field",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1994,6 +1994,7 @@
     }
   },
   "profile": {
+    "edit_manager_profile": "Editar perfil del Manager",
     "description": "Personaliza la información básica y el comportamiento del agente",
     "save_btn": "Guardar cambios",
     "invalid_field": "Campo obligatorio",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1994,6 +1994,7 @@
     }
   },
   "profile": {
+    "edit_manager_profile": "Editar perfil do Manager",
     "description": "Personalize as informações básicas e o comportamento do agente",
     "save_btn": "Salvar alterações",
     "invalid_field": "Campo obrigatório",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -195,11 +195,6 @@ const router = createRouter({
           component: () => import('@/views/AgentBuilder/Supervisor/index.vue'),
         },
         {
-          path: 'profile',
-          name: 'profile',
-          component: () => import('@/views/AgentBuilder/Profile.vue'),
-        },
-        {
           path: 'instructions',
           name: 'instructions',
           component: () =>

--- a/src/views/AgentBuilder/Knowledge.vue
+++ b/src/views/AgentBuilder/Knowledge.vue
@@ -1,7 +1,11 @@
 <template>
-  <BrainHeader data-testid="brain-header" />
-
   <section class="knowledge">
+    <AgentBuilderHeader
+      data-testid="knowledge-header"
+      :withDivider="false"
+      actionsSize="none"
+    />
+
     <RouterContentBase
       data-testid="router-content-base"
       :filesProp="files"
@@ -25,7 +29,7 @@ import RouterContentBase from '@/views/Brain/RouterContentBase.vue';
 import { useFilesPagination } from '@/views/ContentBases/filesPagination';
 import { useSitesPagination } from '@/views/ContentBases/sitesPagination';
 
-import BrainHeader from '@/components/Brain/BrainHeader.vue';
+import AgentBuilderHeader from '@/components/AgentBuilder/Header.vue';
 
 const route = useRoute();
 const store = useStore();
@@ -85,5 +89,7 @@ onMounted(() => {
   width: 100%;
 
   display: grid;
+  grid-template-rows: auto 1fr;
+  gap: $unnnic-spacing-md;
 }
 </style>

--- a/src/views/AgentBuilder/Profile.vue
+++ b/src/views/AgentBuilder/Profile.vue
@@ -1,9 +1,0 @@
-<template>
-  <BrainHeader />
-  <RouterProfile />
-</template>
-
-<script setup>
-import BrainHeader from '@/components/Brain/BrainHeader.vue';
-import RouterProfile from '@/views/Brain/RouterProfile/index.vue';
-</script>

--- a/src/views/AgentBuilder/Supervisor/__tests__/SupervisorHeader.spec.js
+++ b/src/views/AgentBuilder/Supervisor/__tests__/SupervisorHeader.spec.js
@@ -22,7 +22,7 @@ const pinia = createTestingPinia({
   },
 });
 
-vi.mock('@/composables/useBrainRoutes', () => {
+vi.mock('@/composables/useAgentBuilderViews', () => {
   return {
     default: vi.fn(() => {
       return {

--- a/src/views/AgentBuilder/Tunings.vue
+++ b/src/views/AgentBuilder/Tunings.vue
@@ -1,6 +1,16 @@
 <template>
-  <BrainHeader data-testid="brain-header" />
   <section class="tunings">
+    <AgentBuilderHeader
+      data-testid="tunings-header"
+      class="tunings__header"
+      :withDivider="false"
+      actionsSize="md"
+    >
+      <template #actions>
+        <TuningsHeaderActions />
+      </template>
+    </AgentBuilderHeader>
+
     <section class="tunings__tabs">
       <UnnnicTab
         data-testid="unnnic-tab"
@@ -41,10 +51,11 @@ import { ref, onMounted } from 'vue';
 
 import { useTuningsStore } from '@/store/Tunings';
 
-import BrainHeader from '@/components/Brain/BrainHeader.vue';
 import ChangesHistory from '@/components/Brain/Tunings/ChangesHistory.vue';
 import Settings from '@/components/Brain/Tunings/SettingsAgentsTeam/index.vue';
 import Credentials from '@/components/Brain/Tunings/Credentials/index.vue';
+import AgentBuilderHeader from '@/components/AgentBuilder/Header.vue';
+import TuningsHeaderActions from '@/components/TuningsHeaderActions.vue';
 
 const tabs = ref(
   [
@@ -77,10 +88,12 @@ const onTabChange = (newTab) => {
 
 <style lang="scss" scoped>
 .tunings {
-  &__tabs {
-    :deep(.tab-header) {
-      margin-bottom: $unnnic-spacing-md;
-    }
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-spacing-md;
+
+  :deep(.tab-header) {
+    margin: 0;
   }
 }
 </style>

--- a/src/views/AgentBuilder/__tests__/AgentBuilder.spec.js
+++ b/src/views/AgentBuilder/__tests__/AgentBuilder.spec.js
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { useTuningsStore } from '@/store/Tunings';
 import { useAgentsTeamStore } from '@/store/AgentsTeam';
+import { useProfileStore } from '@/store/Profile';
 
 import AgentBuilder from '@/views/AgentBuilder/index.vue';
 
@@ -28,6 +29,7 @@ describe('AgentBuilder.vue', () => {
   let wrapper;
   let tuningsStore;
   let agentsTeamStore;
+  let profileStore;
 
   const sidebar = () =>
     wrapper.findComponent('[data-testid="agent-builder-sidebar"]');
@@ -52,6 +54,7 @@ describe('AgentBuilder.vue', () => {
 
     tuningsStore = useTuningsStore();
     agentsTeamStore = useAgentsTeamStore();
+    profileStore = useProfileStore();
   });
 
   describe('Component rendering', () => {

--- a/src/views/AgentBuilder/__tests__/Knowledge.spec.js
+++ b/src/views/AgentBuilder/__tests__/Knowledge.spec.js
@@ -63,8 +63,8 @@ vi.mock('@/views/ContentBases/sitesPagination', () => ({
 describe('Knowledge.vue', () => {
   let wrapper;
 
-  const brainHeader = () =>
-    wrapper.findComponent('[data-testid="brain-header"]');
+  const header = () =>
+    wrapper.findComponent('[data-testid="knowledge-header"]');
   const routerContentBase = () =>
     wrapper.findComponent('[data-testid="router-content-base"]');
 
@@ -79,7 +79,7 @@ describe('Knowledge.vue', () => {
   describe('Component rendering', () => {
     it('renders correctly', () => {
       expect(wrapper.exists()).toBe(true);
-      expect(brainHeader().exists()).toBe(true);
+      expect(header().exists()).toBe(true);
       expect(routerContentBase().exists()).toBe(true);
     });
 

--- a/src/views/AgentBuilder/__tests__/Tunings.spec.js
+++ b/src/views/AgentBuilder/__tests__/Tunings.spec.js
@@ -12,8 +12,7 @@ describe('Tunings.vue', () => {
   let wrapper;
   let tuningsStore;
 
-  const brainHeader = () =>
-    wrapper.findComponent('[data-testid="brain-header"]');
+  const header = () => wrapper.findComponent('[data-testid="tunings-header"]');
   const unnnicTab = () => wrapper.findComponent('[data-testid="unnnic-tab"]');
   const credentials = () =>
     wrapper.findComponent('[data-testid="credentials"]');
@@ -33,7 +32,7 @@ describe('Tunings.vue', () => {
 
   describe('Component rendering', () => {
     it('renders correctly', () => {
-      expect(brainHeader().exists()).toBe(true);
+      expect(header().exists()).toBe(true);
       expect(unnnicTab().exists()).toBe(true);
     });
 

--- a/src/views/AgentBuilder/index.vue
+++ b/src/views/AgentBuilder/index.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="agent-builder">
-    <BrainSideBar
+    <Sidebar
       class="agent-builder__sidebar"
       data-testid="agent-builder-sidebar"
     />
@@ -40,7 +40,7 @@ import Instructions from './Instructions/index.vue';
 import Knowledge from './Knowledge.vue';
 import Profile from '@/views/AgentBuilder/Profile.vue';
 import Tunings from '@/views/AgentBuilder/Tunings.vue';
-import BrainSideBar from '@/components/Brain/BrainSideBar.vue';
+import Sidebar from '@/components/AgentBuilder/Sidebar.vue';
 import ModalSaveChangesError from '../Brain/ModalSaveChangesError.vue';
 
 const route = useRoute();

--- a/src/views/AgentBuilder/index.vue
+++ b/src/views/AgentBuilder/index.vue
@@ -29,6 +29,7 @@ import { useStore } from 'vuex';
 import { useTuningsStore } from '@/store/Tunings';
 import { useAgentsTeamStore } from '@/store/AgentsTeam';
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
+import { useProfileStore } from '@/store/Profile';
 
 import Supervisor from './Supervisor/index.vue';
 import OldSupervisor from './OldSupervisor/index.vue';
@@ -63,6 +64,7 @@ onMounted(() => {
   agentsTeamStore.loadActiveTeam();
   agentsTeamStore.loadOfficialAgents();
   agentsTeamStore.loadMyAgents();
+  useProfileStore().load();
 });
 </script>
 

--- a/src/views/AgentBuilder/index.vue
+++ b/src/views/AgentBuilder/index.vue
@@ -38,7 +38,6 @@ import OldSupervisor from './OldSupervisor/index.vue';
 import AgentsTeam from './AgentsTeam/index.vue';
 import Instructions from './Instructions/index.vue';
 import Knowledge from './Knowledge.vue';
-import Profile from '@/views/AgentBuilder/Profile.vue';
 import Tunings from '@/views/AgentBuilder/Tunings.vue';
 import Sidebar from '@/components/AgentBuilder/Sidebar.vue';
 import ModalSaveChangesError from '../Brain/ModalSaveChangesError.vue';
@@ -50,14 +49,13 @@ const agentsTeamStore = useAgentsTeamStore();
 
 const currentView = computed(() => {
   const views = {
-    knowledge: Knowledge,
     supervisor: useFeatureFlagsStore().flags.newSupervisor
       ? Supervisor
       : OldSupervisor,
-    agents: AgentsTeam,
-    profile: Profile,
-    tunings: Tunings,
     instructions: Instructions,
+    agents: AgentsTeam,
+    knowledge: Knowledge,
+    tunings: Tunings,
   };
 
   return views[route.name];

--- a/src/views/AgentBuilder/index.vue
+++ b/src/views/AgentBuilder/index.vue
@@ -1,9 +1,6 @@
 <template>
   <section class="agent-builder">
-    <Sidebar
-      class="agent-builder__sidebar"
-      data-testid="agent-builder-sidebar"
-    />
+    <Sidebar data-testid="agent-builder-sidebar" />
 
     <main
       class="agent-builder__content"
@@ -39,7 +36,7 @@ import AgentsTeam from './AgentsTeam/index.vue';
 import Instructions from './Instructions/index.vue';
 import Knowledge from './Knowledge.vue';
 import Tunings from '@/views/AgentBuilder/Tunings.vue';
-import Sidebar from '@/components/AgentBuilder/Sidebar.vue';
+import Sidebar from '@/components/AgentBuilder/Sidebar/index.vue';
 import ModalSaveChangesError from '../Brain/ModalSaveChangesError.vue';
 
 const route = useRoute();
@@ -49,13 +46,13 @@ const agentsTeamStore = useAgentsTeamStore();
 
 const currentView = computed(() => {
   const views = {
+    knowledge: Knowledge,
     supervisor: useFeatureFlagsStore().flags.newSupervisor
       ? Supervisor
       : OldSupervisor,
-    instructions: Instructions,
     agents: AgentsTeam,
-    knowledge: Knowledge,
     tunings: Tunings,
+    instructions: Instructions,
   };
 
   return views[route.name];
@@ -82,10 +79,6 @@ onMounted(() => {
 
   height: 100vh;
   width: 100vw;
-
-  .agent-builder__sidebar {
-    border-right: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-  }
 
   .agent-builder__content {
     padding: $unnnic-spacing-sm;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Remove profile view and trigger a drawer for profile changes

### Summary of Changes
- Created sidebar component of AgentBuilder 2.0 copied of BrainSidebar;
- Removed dependency on AgentBuilder 2.0 with useBrainRoutes and created composable useAgentBuilderViews with tests;
- Removed Profile view and route from Agent Builder 2.0;
- Implemented Sidebar and SidebarHeader components for AgentBuilder 2.0;
- Replaced BrainHeader of Knowledge and Tunings views to AgentBuilderHeader.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File](https://www.figma.com/design/8SxtxpzEI8Fe8OMrnYJOjy/Profile?node-id=4161-2569&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
<img width="180" height="378" alt="image" src="https://github.com/user-attachments/assets/2f31650b-789f-4a61-9e63-06e42e3dc0cd" />


