### PR TITLE
[NEXUS-3763] - Fix profile goal max length

### DIFF
--- a/src/views/Brain/RouterProfile/RouterProfileGeneralInfo.vue
+++ b/src/views/Brain/RouterProfile/RouterProfileGeneralInfo.vue
@@ -60,7 +60,7 @@
         :error="errorRequiredFields.goal ? $t('profile.invalid_field') : null"
         :placeholder="$t('profile.fields.goal.placeholder')"
         :type="errorRequiredFields.goal ? 'error' : 'normal'"
-        :maxLength="200"
+        :maxLength="500"
       />
     </section>
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The profile goal field character limit was too low for the amount users need.

### Summary of Changes
<!--- Describe your changes in detail -->
Increase maxLength for profile goal input field from 200 to 500
