### PR TITLE
[NEXUS-3771] - Remove instructions max length

### DIFF
--- a/src/components/AgentBuilder/Instructions/Instruction.vue
+++ b/src/components/AgentBuilder/Instructions/Instruction.vue
@@ -7,15 +7,8 @@
           class="input__field"
           data-testid="instruction-input"
           size="sm"
-          :maxLength="MAX_INSTRUCTION_LENGTH"
           @keyup.enter="saveEditingInstruction"
         />
-        <p
-          class="input__length"
-          data-testid="instruction-input-length"
-        >
-          {{ editingText.length }} / {{ MAX_INSTRUCTION_LENGTH }}
-        </p>
       </section>
       <UnnnicButton
         :text="$t('agent_builder.instructions.edit_instruction.save')"

--- a/src/components/AgentBuilder/Instructions/NewInstruction.vue
+++ b/src/components/AgentBuilder/Instructions/NewInstruction.vue
@@ -18,7 +18,6 @@
       :message="
         $t('agent_builder.instructions.new_instruction.textarea.description')
       "
-      :maxLength="200"
     />
     <UnnnicButton
       class="new-instruction__add-instruction-button"

--- a/src/components/AgentBuilder/Instructions/__tests__/Instruction.spec.js
+++ b/src/components/AgentBuilder/Instructions/__tests__/Instruction.spec.js
@@ -42,7 +42,6 @@ describe('Instruction.vue', () => {
     tag: '[data-testid="instruction-tag"]',
     actions: '[data-testid="instruction-actions"]',
     input: '[data-testid="instruction-input"]',
-    inputLength: '[data-testid="instruction-input-length"]',
     saveButton: '[data-testid="instruction-save-button"]',
     cancelButton: '[data-testid="instruction-cancel-button"]',
     modalRemoveInstruction: '[data-testid="modal-remove-instruction"]',
@@ -138,7 +137,6 @@ describe('Instruction.vue', () => {
 
     it('renders the correct components', async () => {
       expect(findComponent('input').exists()).toBe(true);
-      expect(find('inputLength').exists()).toBe(true);
       expect(findComponent('saveButton').exists()).toBe(true);
       expect(findComponent('cancelButton').exists()).toBe(true);
       expect(findComponent('text').exists()).toBe(false);
@@ -151,12 +149,6 @@ describe('Instruction.vue', () => {
         'Test instruction',
       );
       expect(findComponent('input').props('size')).toBe('sm');
-    });
-
-    it('renders the correct input length', () => {
-      expect(find('inputLength').text()).toBe(
-        `${wrapper.vm.editingText.length} / ${wrapper.vm.MAX_INSTRUCTION_LENGTH}`,
-      );
     });
 
     it('renders the correct save button', () => {

--- a/src/components/AgentBuilder/Instructions/__tests__/NewInstruction.spec.js
+++ b/src/components/AgentBuilder/Instructions/__tests__/NewInstruction.spec.js
@@ -72,7 +72,6 @@ describe('NewInstruction.vue', () => {
         expect(findComponent('textarea').props('message')).toBe(
           translation('textarea.description'),
         );
-        expect(findComponent('textarea').props('maxLength')).toBe(200);
       });
     });
 

--- a/src/components/AgentBuilder/Instructions/__tests__/__snapshots__/Instruction.spec.js.snap
+++ b/src/components/AgentBuilder/Instructions/__tests__/__snapshots__/Instruction.spec.js.snap
@@ -12,8 +12,7 @@ exports[`Instruction.vue > Component rendering > should match snapshot 1`] = `
 exports[`Instruction.vue > Edit mode > should match snapshot > edit-mode 1`] = `
 "<section data-v-cba3a9e7="" class="instruction">
   <section data-v-cba3a9e7="" class="instruction__input">
-    <unnnic-input-stub data-v-cba3a9e7="" placeholder="" type="normal" modelvalue="Test instruction" nativetype="text" allowtogglepassword="false" hascloudycolor="false" size="sm" mask="" class="input__field" data-testid="instruction-input" maxlength="200"></unnnic-input-stub>
-    <p data-v-cba3a9e7="" class="input__length" data-testid="instruction-input-length">16 / 200</p>
+    <unnnic-input-stub data-v-cba3a9e7="" placeholder="" type="normal" modelvalue="Test instruction" nativetype="text" allowtogglepassword="false" hascloudycolor="false" size="sm" mask="" class="input__field" data-testid="instruction-input"></unnnic-input-stub>
   </section>
   <unnnic-button-stub data-v-cba3a9e7="" size="small" text="Save" type="secondary" float="false" iconleft="" iconright="" iconcenter="" iconsfilled="false" next="false" disabled="false" loading="false" data-testid="instruction-save-button"></unnnic-button-stub>
   <unnnic-button-stub data-v-cba3a9e7="" size="small" text="Cancel" type="tertiary" float="false" iconleft="" iconright="" iconcenter="" iconsfilled="false" next="false" disabled="false" loading="false" data-testid="instruction-cancel-button"></unnnic-button-stub>

--- a/src/components/AgentBuilder/Instructions/__tests__/__snapshots__/NewInstruction.spec.js.snap
+++ b/src/components/AgentBuilder/Instructions/__tests__/__snapshots__/NewInstruction.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`NewInstruction.vue > Component rendering > should match snapshot 1`] = `
 "<section data-v-5fa2c1a3="" class="new-instruction" data-testid="new-instruction">
   <h2 data-v-5fa2c1a3="" class="new-instruction__title" data-testid="new-instruction-title">New custom instruction</h2>
-  <anonymous-stub data-v-5fa2c1a3="" modelvalue="" placeholder="You're funny, but don't make jokes" maxlength="200" size="md" message="Keep instructions clear, direct, and in the imperative." disabled="false" type="normal" errors="" data-testid="new-instruction-textarea"></anonymous-stub>
+  <anonymous-stub data-v-5fa2c1a3="" modelvalue="" placeholder="You're funny, but don't make jokes" size="md" message="Keep instructions clear, direct, and in the imperative." disabled="false" type="normal" errors="" data-testid="new-instruction-textarea"></anonymous-stub>
   <unnnic-button-stub data-v-5fa2c1a3="" size="large" text="Add instruction" type="primary" float="false" iconleft="" iconright="" iconcenter="" iconsfilled="false" next="false" disabled="true" loading="false" class="new-instruction__add-instruction-button" data-testid="add-instruction-button"></unnnic-button-stub>
 </section>"
 `;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users were complaining about a low limit, so it was decided to remove this limit temporarily.

### Summary of Changes
<!--- Describe your changes in detail -->
Removed maxLength attribute and input length display at instruction edit and new instruction textarea