### PR TITLE
[NEXUS-3748] - Filter drawer in Supervisor

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -140,6 +140,9 @@
         "filter_conversations_drawer": "Filter conversations",
         "apply_filters": "Apply filters",
         "clear_filters": "Clear filters",
+        "period": {
+          "label": "Period"
+        },
         "status": {
           "conversations": "Conversations",
           "in_progress": "In progress",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -135,6 +135,7 @@
         "error": "Error sending export. Try again later."
       },
       "filters": {
+        "filter_conversations": "Filter conversations",
         "status": {
           "conversations": "Conversations",
           "in_progress": "In progress",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,6 +136,9 @@
       },
       "filters": {
         "filter_conversations": "Filter conversations",
+        "filter_conversations_drawer": "Filter conversations",
+        "apply_filters": "Apply filters",
+        "clear_filters": "Clear filters",
         "status": {
           "conversations": "Conversations",
           "in_progress": "In progress",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,6 +136,7 @@
       },
       "filters": {
         "filter_conversations": "Filter conversations",
+        "count_applied_filters": "(1 filter applied) | ({count} filters applied)",
         "filter_conversations_drawer": "Filter conversations",
         "apply_filters": "Apply filters",
         "clear_filters": "Clear filters",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -139,6 +139,7 @@
         "error": "Error al enviar exportación. Inténtalo de nuevo más tarde."
       },
       "filters": {
+        "filter_conversations": "Filtrar conversaciones",
         "status": {
           "conversations": "Conversaciones",
           "in_progress": "En progreso",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -144,6 +144,9 @@
         "filter_conversations_drawer": "Filtrar conversaciones",
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpiar filtros",
+        "period": {
+          "label": "Período"
+        },
         "status": {
           "conversations": "Conversaciones",
           "in_progress": "En progreso",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -140,6 +140,9 @@
       },
       "filters": {
         "filter_conversations": "Filtrar conversaciones",
+        "filter_conversations_drawer": "Filtrar conversaciones",
+        "apply_filters": "Aplicar filtros",
+        "clear_filters": "Limpiar filtros",
         "status": {
           "conversations": "Conversaciones",
           "in_progress": "En progreso",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -140,6 +140,7 @@
       },
       "filters": {
         "filter_conversations": "Filtrar conversaciones",
+        "count_applied_filters": "(1 filtro aplicado) | ({count} filtros aplicados)",
         "filter_conversations_drawer": "Filtrar conversaciones",
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpiar filtros",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -144,6 +144,9 @@
         "filter_conversations_drawer": "Filtrar conversas",
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpar filtros",
+        "period": {
+          "label": "Período"
+        },
         "status": {
           "conversations": "Conversas",
           "in_progress": "Em progresso",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -139,6 +139,7 @@
         "error": "Erro ao enviar exportação. Tente novamente mais tarde."
       },
       "filters": {
+        "filter_conversations": "Filtrar conversas",
         "status": {
           "conversations": "Conversas",
           "in_progress": "Em progresso",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -140,6 +140,7 @@
       },
       "filters": {
         "filter_conversations": "Filtrar conversas",
+        "count_applied_filters": "(1 filtro aplicado) | ({count} filtros aplicados)",
         "filter_conversations_drawer": "Filtrar conversas",
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpar filtros",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -140,6 +140,9 @@
       },
       "filters": {
         "filter_conversations": "Filtrar conversas",
+        "filter_conversations_drawer": "Filtrar conversas",
+        "apply_filters": "Aplicar filtros",
+        "clear_filters": "Limpar filtros",
         "status": {
           "conversations": "Conversas",
           "in_progress": "Em progresso",

--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -28,16 +28,52 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
 
   let conversationsAbortController = null;
 
+  const defaultFilters = {
+    start: thisMonth,
+    end: today,
+    search: '',
+    status: [],
+    csat: [],
+    topics: [],
+  };
+
   const filters = reactive({
-    start: route?.query.start || thisMonth,
-    end: route?.query.end || today,
-    search: route?.query.search || '',
-    status: route?.query.status || [],
-    csat: route?.query.csat || [],
-    topics: route?.query.topics || [],
+    start: route?.query.start || defaultFilters.start,
+    end: route?.query.end || defaultFilters.end,
+    search: route?.query.search || defaultFilters.search,
+    status: route?.query.status || defaultFilters.status,
+    csat: route?.query.csat || defaultFilters.csat,
+    topics: route?.query.topics || defaultFilters.topics,
+  });
+
+  const temporaryFilters = reactive({
+    start: filters.start,
+    end: filters.end,
+    search: filters.search,
+    status: filters.status,
+    csat: filters.csat,
+    topics: filters.topics,
   });
 
   const queryConversationUuid = ref(route?.query.uuid || '');
+
+  function resetTemporaryFilters() {
+    temporaryFilters.start = defaultFilters.start;
+    temporaryFilters.end = defaultFilters.end;
+    temporaryFilters.search = defaultFilters.search;
+    temporaryFilters.status = defaultFilters.status;
+    temporaryFilters.csat = defaultFilters.csat;
+    temporaryFilters.topics = defaultFilters.topics;
+  }
+
+  function updateFilters() {
+    filters.start = temporaryFilters.start;
+    filters.end = temporaryFilters.end;
+    filters.search = temporaryFilters.search;
+    filters.status = temporaryFilters.status;
+    filters.csat = temporaryFilters.csat;
+    filters.topics = temporaryFilters.topics;
+  }
 
   async function loadConversations(page = 1) {
     if (conversationsAbortController) {
@@ -186,8 +222,11 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     selectConversation,
     selectedConversation,
     filters,
+    temporaryFilters,
     queryConversationUuid,
     getTopics,
     exportSupervisorData,
+    resetTemporaryFilters,
+    updateFilters,
   };
 });

--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -14,6 +14,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
   const supervisorApi = nexusaiAPI.agent_builder.supervisor;
   const alertStore = useAlertStore();
   const route = useRoute();
+  const { query } = route || {};
   const thisMonth = format(subDays(new Date(), 29), 'yyyy-MM-dd');
   const today = format(new Date(), 'yyyy-MM-dd');
 
@@ -37,13 +38,14 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     topics: [],
   };
 
+  const parseArray = (value) => value?.split(',').filter(Boolean) || null;
   const filters = reactive({
-    start: route?.query.start || defaultFilters.start,
-    end: route?.query.end || defaultFilters.end,
-    search: route?.query.search || defaultFilters.search,
-    status: route?.query.status?.split(',') || defaultFilters.status,
-    csat: route?.query.csat?.split(',') || defaultFilters.csat,
-    topics: route?.query.topics?.split(',') || defaultFilters.topics,
+    start: query?.start ?? defaultFilters.start,
+    end: query?.end ?? defaultFilters.end,
+    search: query?.search ?? defaultFilters.search,
+    status: parseArray(query?.status) || defaultFilters.status,
+    csat: parseArray(query?.csat) || defaultFilters.csat,
+    topics: parseArray(query?.topics) || defaultFilters.topics,
   });
 
   const temporaryFilters = reactive({
@@ -57,7 +59,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
 
   const topics = ref([]);
 
-  const queryConversationUuid = ref(route?.query.uuid || '');
+  const queryConversationUuid = ref(query?.uuid || '');
 
   function resetFilters() {
     const { start, end, status, csat, topics } = defaultFilters;

--- a/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/ConversationRow.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorConversations/ConversationsTable/ConversationRow.vue
@@ -112,7 +112,7 @@ const statusProps = computed(() => {
       scheme: 'aux-red-500',
     },
     unclassified: {
-      scheme: 'gray-500',
+      scheme: 'neutral-cloudy',
     },
   };
 

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterCsat.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterCsat.vue
@@ -1,0 +1,59 @@
+<template>
+  <UnnnicSelectSmart
+    v-model:modelValue="csatFilter"
+    :options="csatOptions"
+    orderedByIndex
+    multiple
+    multipleWithoutSelectsMessage
+    autocomplete
+  />
+</template>
+
+<script setup>
+import { ref, watch, computed } from 'vue';
+import i18n from '@/utils/plugins/i18n';
+
+import { useSupervisorStore } from '@/store/Supervisor';
+
+const supervisorStore = useSupervisorStore();
+
+function getQueryFilterArray(filter, filterOptions) {
+  if (!supervisorStore.filters[filter]) return [];
+  if (typeof supervisorStore.filters[filter] !== 'string')
+    return supervisorStore.filters[filter];
+
+  return supervisorStore.filters[filter].split(',').map((item) => {
+    if (item === '') return { label: '', value: '' };
+
+    return filterOptions.value.find(
+      (option) => option.value === item || option.label === item,
+    );
+  });
+}
+
+const getCsatTranslation = (filter) =>
+  i18n.global.t(`agent_builder.supervisor.filters.csat.${filter}`);
+
+const csatOptions = computed(() => [
+  { label: getCsatTranslation('csat'), value: '' },
+  { label: getCsatTranslation('very_satisfied'), value: 'very_satisfied' },
+  { label: getCsatTranslation('satisfied'), value: 'satisfied' },
+  { label: getCsatTranslation('neutral'), value: 'neutral' },
+  { label: getCsatTranslation('dissatisfied'), value: 'dissatisfied' },
+  {
+    label: getCsatTranslation('very_dissatisfied'),
+    value: 'very_dissatisfied',
+  },
+]);
+const csatFilter = ref(getQueryFilterArray('csat', csatOptions));
+
+watch(
+  () => csatFilter.value,
+  () => {
+    supervisorStore.filters.csat = csatFilter.value.map(
+      (csat) => csat?.value || '',
+    );
+  },
+  { immediate: true, deep: true },
+);
+</script>

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterCsat.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterCsat.vue
@@ -1,12 +1,14 @@
 <template>
-  <UnnnicSelectSmart
-    v-model:modelValue="csatFilter"
-    :options="csatOptions"
-    orderedByIndex
-    multiple
-    multipleWithoutSelectsMessage
-    autocomplete
-  />
+  <UnnnicFormElement :label="$t('agent_builder.supervisor.filters.csat.csat')">
+    <UnnnicSelectSmart
+      v-model:modelValue="csatFilter"
+      :options="csatOptions"
+      orderedByIndex
+      multiple
+      multipleWithoutSelectsMessage
+      autocomplete
+    />
+  </UnnnicFormElement>
 </template>
 
 <script setup>

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterCsat.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterCsat.vue
@@ -17,40 +17,31 @@ import { useSupervisorStore } from '@/store/Supervisor';
 
 const supervisorStore = useSupervisorStore();
 
-function getQueryFilterArray(filter, filterOptions) {
-  if (!supervisorStore.filters[filter]) return [];
-  if (typeof supervisorStore.filters[filter] !== 'string')
-    return supervisorStore.filters[filter];
-
-  return supervisorStore.filters[filter].split(',').map((item) => {
-    if (item === '') return { label: '', value: '' };
-
-    return filterOptions.value.find(
-      (option) => option.value === item || option.label === item,
-    );
-  });
-}
-
 const getCsatTranslation = (filter) =>
   i18n.global.t(`agent_builder.supervisor.filters.csat.${filter}`);
 
 const csatOptions = computed(() => [
   { label: getCsatTranslation('csat'), value: '' },
-  { label: getCsatTranslation('very_satisfied'), value: 'very_satisfied' },
-  { label: getCsatTranslation('satisfied'), value: 'satisfied' },
-  { label: getCsatTranslation('neutral'), value: 'neutral' },
-  { label: getCsatTranslation('dissatisfied'), value: 'dissatisfied' },
-  {
-    label: getCsatTranslation('very_dissatisfied'),
-    value: 'very_dissatisfied',
-  },
+  ...[
+    'very_satisfied',
+    'satisfied',
+    'neutral',
+    'dissatisfied',
+    'very_dissatisfied',
+  ].map((value) => ({
+    label: getCsatTranslation(value),
+    value,
+  })),
 ]);
-const csatFilter = ref(getQueryFilterArray('csat', csatOptions));
+
+const csatFilter = ref(
+  supervisorStore.getInitialSelectFilter('csat', csatOptions),
+);
 
 watch(
   () => csatFilter.value,
   () => {
-    supervisorStore.filters.csat = csatFilter.value.map(
+    supervisorStore.temporaryFilters.csat = csatFilter.value.map(
       (csat) => csat?.value || '',
     );
   },

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterDate.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterDate.vue
@@ -1,0 +1,41 @@
+<template>
+  <UnnnicInputDatePicker
+    v-model="dateFilter"
+    position="right"
+    class="supervisor-filter-date"
+    :maxDate="today"
+    data-testid="date-picker"
+  />
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import { format } from 'date-fns';
+
+import { useSupervisorStore } from '@/store/Supervisor';
+
+const supervisorStore = useSupervisorStore();
+
+const today = format(new Date(), 'yyyy-MM-dd');
+const dateFilter = ref({
+  start: supervisorStore.filters.start,
+  end: supervisorStore.filters.end,
+});
+
+watch(
+  () => dateFilter.value,
+  () => {
+    supervisorStore.filters.start = dateFilter.value.start;
+    supervisorStore.filters.end = dateFilter.value.end;
+  },
+  { immediate: true },
+);
+</script>
+
+<style lang="scss" scoped>
+.supervisor-filter-date {
+  :deep(.input) {
+    width: 100%;
+  }
+}
+</style>

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterDate.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterDate.vue
@@ -1,11 +1,15 @@
 <template>
-  <UnnnicInputDatePicker
-    v-model="dateFilter"
-    position="right"
-    class="supervisor-filter-date"
-    :maxDate="today"
-    data-testid="date-picker"
-  />
+  <UnnnicFormElement
+    :label="$t('agent_builder.supervisor.filters.period.label')"
+  >
+    <UnnnicInputDatePicker
+      v-model="dateFilter"
+      position="right"
+      class="supervisor-filter-date"
+      :maxDate="today"
+      data-testid="date-picker"
+    />
+  </UnnnicFormElement>
 </template>
 
 <script setup>
@@ -34,6 +38,8 @@ watch(
 
 <style lang="scss" scoped>
 .supervisor-filter-date {
+  width: 100%;
+
   :deep(.input) {
     width: 100%;
   }

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterDate.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterDate.vue
@@ -18,15 +18,15 @@ const supervisorStore = useSupervisorStore();
 
 const today = format(new Date(), 'yyyy-MM-dd');
 const dateFilter = ref({
-  start: supervisorStore.filters.start,
-  end: supervisorStore.filters.end,
+  start: supervisorStore.temporaryFilters.start,
+  end: supervisorStore.temporaryFilters.end,
 });
 
 watch(
   () => dateFilter.value,
   () => {
-    supervisorStore.filters.start = dateFilter.value.start;
-    supervisorStore.filters.end = dateFilter.value.end;
+    supervisorStore.temporaryFilters.start = dateFilter.value.start;
+    supervisorStore.temporaryFilters.end = dateFilter.value.end;
   },
   { immediate: true },
 );

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterStatus.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterStatus.vue
@@ -17,46 +17,31 @@ import { useSupervisorStore } from '@/store/Supervisor';
 
 const supervisorStore = useSupervisorStore();
 
-function getQueryFilterArray(filter, filterOptions) {
-  if (!supervisorStore.filters[filter]) return [];
-  if (typeof supervisorStore.filters[filter] !== 'string')
-    return supervisorStore.filters[filter];
-
-  return supervisorStore.filters[filter].split(',').map((item) => {
-    if (item === '') return { label: '', value: '' };
-
-    return filterOptions.value.find(
-      (option) => option.value === item || option.label === item,
-    );
-  });
-}
-
 const getStatusTranslation = (filter) =>
   i18n.global.t(`agent_builder.supervisor.filters.status.${filter}`);
 
 const statusOptions = computed(() => [
   { label: getStatusTranslation('conversations'), value: '' },
-  {
-    label: getStatusTranslation('optimized_resolution'),
-    value: 'optimized_resolution',
-  },
-  {
-    label: getStatusTranslation('other_conclusion'),
-    value: 'other_conclusion',
-  },
-  {
-    label: getStatusTranslation('transferred_to_human_support'),
-    value: 'transferred_to_human_support',
-  },
-  { label: getStatusTranslation('in_progress'), value: 'in_progress' },
-  { label: getStatusTranslation('unclassified'), value: 'unclassified' },
+  ...[
+    'optimized_resolution',
+    'other_conclusion',
+    'transferred_to_human_support',
+    'in_progress',
+    'unclassified',
+  ].map((value) => ({
+    label: getStatusTranslation(value),
+    value,
+  })),
 ]);
-const statusFilter = ref(getQueryFilterArray('status', statusOptions));
+
+const statusFilter = ref(
+  supervisorStore.getInitialSelectFilter('status', statusOptions),
+);
 
 watch(
   () => statusFilter.value,
   () => {
-    supervisorStore.filters.status = statusFilter.value.map(
+    supervisorStore.temporaryFilters.status = statusFilter.value.map(
       (status) => status?.value || '',
     );
   },

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterStatus.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterStatus.vue
@@ -1,12 +1,16 @@
 <template>
-  <UnnnicSelectSmart
-    v-model:modelValue="statusFilter"
-    :options="statusOptions"
-    orderedByIndex
-    multiple
-    multipleWithoutSelectsMessage
-    autocomplete
-  />
+  <UnnnicFormElement
+    :label="$t('agent_builder.supervisor.filters.status.conversations')"
+  >
+    <UnnnicSelectSmart
+      v-model:modelValue="statusFilter"
+      :options="statusOptions"
+      orderedByIndex
+      multiple
+      multipleWithoutSelectsMessage
+      autocomplete
+    />
+  </UnnnicFormElement>
 </template>
 
 <script setup>

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterStatus.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterStatus.vue
@@ -1,0 +1,65 @@
+<template>
+  <UnnnicSelectSmart
+    v-model:modelValue="statusFilter"
+    :options="statusOptions"
+    orderedByIndex
+    multiple
+    multipleWithoutSelectsMessage
+    autocomplete
+  />
+</template>
+
+<script setup>
+import { ref, watch, computed } from 'vue';
+import i18n from '@/utils/plugins/i18n';
+
+import { useSupervisorStore } from '@/store/Supervisor';
+
+const supervisorStore = useSupervisorStore();
+
+function getQueryFilterArray(filter, filterOptions) {
+  if (!supervisorStore.filters[filter]) return [];
+  if (typeof supervisorStore.filters[filter] !== 'string')
+    return supervisorStore.filters[filter];
+
+  return supervisorStore.filters[filter].split(',').map((item) => {
+    if (item === '') return { label: '', value: '' };
+
+    return filterOptions.value.find(
+      (option) => option.value === item || option.label === item,
+    );
+  });
+}
+
+const getStatusTranslation = (filter) =>
+  i18n.global.t(`agent_builder.supervisor.filters.status.${filter}`);
+
+const statusOptions = computed(() => [
+  { label: getStatusTranslation('conversations'), value: '' },
+  {
+    label: getStatusTranslation('optimized_resolution'),
+    value: 'optimized_resolution',
+  },
+  {
+    label: getStatusTranslation('other_conclusion'),
+    value: 'other_conclusion',
+  },
+  {
+    label: getStatusTranslation('transferred_to_human_support'),
+    value: 'transferred_to_human_support',
+  },
+  { label: getStatusTranslation('in_progress'), value: 'in_progress' },
+  { label: getStatusTranslation('unclassified'), value: 'unclassified' },
+]);
+const statusFilter = ref(getQueryFilterArray('status', statusOptions));
+
+watch(
+  () => statusFilter.value,
+  () => {
+    supervisorStore.filters.status = statusFilter.value.map(
+      (status) => status?.value || '',
+    );
+  },
+  { immediate: true, deep: true },
+);
+</script>

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterTopics.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterTopics.vue
@@ -1,0 +1,70 @@
+<template>
+  <UnnnicSelectSmart
+    v-model:modelValue="topicFilter"
+    :options="topicOptions"
+    orderedByIndex
+    multiple
+    multipleWithoutSelectsMessage
+    autocomplete
+  />
+</template>
+
+<script setup>
+import { ref, watch, computed } from 'vue';
+import i18n from '@/utils/plugins/i18n';
+
+import { useSupervisorStore } from '@/store/Supervisor';
+
+const supervisorStore = useSupervisorStore();
+
+function getQueryFilterArray(filter, filterOptions) {
+  if (!supervisorStore.filters[filter]) return [];
+  if (typeof supervisorStore.filters[filter] !== 'string')
+    return supervisorStore.filters[filter];
+
+  return supervisorStore.filters[filter].split(',').map((item) => {
+    if (item === '') return { label: '', value: '' };
+
+    return filterOptions.value.find(
+      (option) => option.value === item || option.label === item,
+    );
+  });
+}
+
+const topicOptions = computed(() => [
+  {
+    label: i18n.global.t(`agent_builder.supervisor.filters.topic.topic`),
+    value: '',
+  },
+]);
+const topicFilter = ref([]);
+
+const isRequestedTopics = ref(false);
+
+watch(
+  () => topicFilter.value,
+  async () => {
+    if (!isRequestedTopics.value) {
+      await getTopics();
+      topicFilter.value = getQueryFilterArray('topics', topicOptions);
+      isRequestedTopics.value = true;
+    }
+    supervisorStore.filters.topics = topicFilter.value.map(
+      (subject) => subject?.label || '',
+    );
+  },
+  { immediate: true, deep: true },
+);
+
+async function getTopics() {
+  await supervisorStore.getTopics().then((topics) => {
+    topicOptions.value = [
+      ...topicOptions.value,
+      ...topics.map((topic) => ({
+        label: topic.name,
+        value: topic.uuid,
+      })),
+    ];
+  });
+}
+</script>

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterTopics.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterTopics.vue
@@ -17,54 +17,24 @@ import { useSupervisorStore } from '@/store/Supervisor';
 
 const supervisorStore = useSupervisorStore();
 
-function getQueryFilterArray(filter, filterOptions) {
-  if (!supervisorStore.filters[filter]) return [];
-  if (typeof supervisorStore.filters[filter] !== 'string')
-    return supervisorStore.filters[filter];
-
-  return supervisorStore.filters[filter].split(',').map((item) => {
-    if (item === '') return { label: '', value: '' };
-
-    return filterOptions.value.find(
-      (option) => option.value === item || option.label === item,
-    );
-  });
-}
-
 const topicOptions = computed(() => [
   {
     label: i18n.global.t(`agent_builder.supervisor.filters.topic.topic`),
     value: '',
   },
+  ...supervisorStore.topics,
 ]);
-const topicFilter = ref([]);
-
-const isRequestedTopics = ref(false);
+const topicFilter = ref(
+  supervisorStore.getInitialSelectFilter('topics', topicOptions),
+);
 
 watch(
   () => topicFilter.value,
-  async () => {
-    if (!isRequestedTopics.value) {
-      await getTopics();
-      topicFilter.value = getQueryFilterArray('topics', topicOptions);
-      isRequestedTopics.value = true;
-    }
-    supervisorStore.filters.topics = topicFilter.value.map(
+  () => {
+    supervisorStore.temporaryFilters.topics = topicFilter.value.map(
       (subject) => subject?.label || '',
     );
   },
   { immediate: true, deep: true },
 );
-
-async function getTopics() {
-  await supervisorStore.getTopics().then((topics) => {
-    topicOptions.value = [
-      ...topicOptions.value,
-      ...topics.map((topic) => ({
-        label: topic.name,
-        value: topic.uuid,
-      })),
-    ];
-  });
-}
 </script>

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterTopics.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/FilterTopics.vue
@@ -1,12 +1,16 @@
 <template>
-  <UnnnicSelectSmart
-    v-model:modelValue="topicFilter"
-    :options="topicOptions"
-    orderedByIndex
-    multiple
-    multipleWithoutSelectsMessage
-    autocomplete
-  />
+  <UnnnicFormElement
+    :label="$t('agent_builder.supervisor.filters.topic.topic')"
+  >
+    <UnnnicSelectSmart
+      v-model:modelValue="topicFilter"
+      :options="topicOptions"
+      orderedByIndex
+      multiple
+      multipleWithoutSelectsMessage
+      autocomplete
+    />
+  </UnnnicFormElement>
 </template>
 
 <script setup>

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/index.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/index.vue
@@ -5,7 +5,7 @@
     <UnnnicButton
       iconLeft="filter_list"
       type="secondary"
-      :text="$t('agent_builder.supervisor.filters.filter_conversations')"
+      :text="filterButtonText"
       data-testid="filter-button"
       @click="openFilterDrawer"
     />
@@ -40,6 +40,8 @@
 import { ref, computed, onMounted } from 'vue';
 import { isEqual } from 'lodash';
 
+import i18n from '@/utils/plugins/i18n';
+
 import { useSupervisorStore } from '@/store/Supervisor';
 
 import FilterText from './FilterText.vue';
@@ -58,6 +60,30 @@ const filterDrawerApplyButtonDisabled = computed(() =>
 const filterDrawerClearButtonDisabled = computed(() =>
   isEqual(supervisorStore.temporaryFilters, supervisorStore.defaultFilters),
 );
+
+const countAppliedFilters = computed(() => {
+  const filtersToCount = ['status', 'csat', 'topics'];
+
+  return filtersToCount.reduce((total, filter) => {
+    return total + supervisorStore.filters[filter].length;
+  }, 0);
+});
+
+const filterButtonText = computed(() => {
+  const { t, tc } = i18n.global;
+  const count = countAppliedFilters.value;
+
+  const text = t('agent_builder.supervisor.filters.filter_conversations');
+  const countText = tc(
+    'agent_builder.supervisor.filters.count_applied_filters',
+    count,
+    {
+      count,
+    },
+  );
+
+  return count > 0 ? `${text} ${countText}` : text;
+});
 
 function openFilterDrawer() {
   isFilterDrawerOpen.value = true;

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/index.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/index.vue
@@ -1,183 +1,60 @@
 <template>
   <section class="supervisor-filters">
-    <!-- <section class="supervisor-filters__selects">
-      <UnnnicInputDatePicker
-        v-model="dateFilter"
-        position="left"
-        class="selects__date-picker"
-        :maxDate="today"
-        data-testid="date-picker"
-      />
-      <UnnnicSelectSmart
-        v-model:modelValue="statusFilter"
-        :options="statusOptions"
-        orderedByIndex
-        multiple
-        multipleWithoutSelectsMessage
-        autocomplete
-      />
-      <UnnnicSelectSmart
-        v-model:modelValue="csatFilter"
-        :options="csatOptions"
-        orderedByIndex
-        multiple
-        multipleWithoutSelectsMessage
-        autocomplete
-      />
-      <UnnnicSelectSmart
-        v-model:modelValue="topicFilter"
-        :options="topicOptions"
-        orderedByIndex
-        multiple
-        multipleWithoutSelectsMessage
-        autocomplete
-      />
-    </section> -->
-
     <FilterText data-testid="filter-text" />
 
     <UnnnicButton
       iconLeft="filter_list"
       type="secondary"
+      :text="$t('agent_builder.supervisor.filters.filter_conversations')"
       data-testid="filter-button"
+      @click="openFilterDrawer"
+    />
+
+    <UnnnicDrawer
+      :modelValue="isFilterDrawerOpen"
+      class="supervisor-filters__drawer"
+      :title="
+        $t('agent_builder.supervisor.filters.filter_conversations_drawer')
+      "
+      :primaryButtonText="$t('agent_builder.supervisor.filters.apply_filters')"
+      :secondaryButtonText="
+        $t('agent_builder.supervisor.filters.clear_filters')
+      "
+      @close="closeFilterDrawerWithReset"
+      @primary-button-click="applyFilters"
+      @secondary-button-click="closeFilterDrawerWithReset"
     >
-      {{ $t('agent_builder.supervisor.filters.filter_conversations') }}
-    </UnnnicButton>
+      <template #content>
+        <FilterDate />
+        <FilterStatus />
+        <FilterCsat />
+        <FilterTopics />
+      </template>
+    </UnnnicDrawer>
   </section>
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue';
+import { ref } from 'vue';
 
 import FilterText from './FilterText.vue';
-import { format } from 'date-fns';
-import { useSupervisorStore } from '@/store/Supervisor';
-import i18n from '@/utils/plugins/i18n';
+import FilterDate from './FilterDate.vue';
+import FilterStatus from './FilterStatus.vue';
+import FilterCsat from './FilterCsat.vue';
+import FilterTopics from './FilterTopics.vue';
 
-const supervisorStore = useSupervisorStore();
+const isFilterDrawerOpen = ref(false);
 
-const today = format(new Date(), 'yyyy-MM-dd');
-function getQueryFilterArray(filter, filterOptions) {
-  if (!supervisorStore.filters[filter]) return [];
-  if (typeof supervisorStore.filters[filter] !== 'string')
-    return supervisorStore.filters[filter];
-
-  return supervisorStore.filters[filter].split(',').map((item) => {
-    if (item === '') return { label: '', value: '' };
-
-    return filterOptions.value.find(
-      (option) => option.value === item || option.label === item,
-    );
-  });
+function openFilterDrawer() {
+  isFilterDrawerOpen.value = true;
 }
 
-const dateFilter = ref({
-  start: supervisorStore.filters.start,
-  end: supervisorStore.filters.end,
-});
+function closeFilterDrawerWithReset() {
+  isFilterDrawerOpen.value = false;
+}
 
-watch(
-  () => dateFilter.value,
-  () => {
-    supervisorStore.filters.start = dateFilter.value.start;
-    supervisorStore.filters.end = dateFilter.value.end;
-  },
-  { immediate: true },
-);
-
-const getStatusTranslation = (filter) =>
-  i18n.global.t(`agent_builder.supervisor.filters.status.${filter}`);
-
-const statusOptions = computed(() => [
-  { label: getStatusTranslation('conversations'), value: '' },
-  {
-    label: getStatusTranslation('optimized_resolution'),
-    value: 'optimized_resolution',
-  },
-  {
-    label: getStatusTranslation('other_conclusion'),
-    value: 'other_conclusion',
-  },
-  {
-    label: getStatusTranslation('transferred_to_human_support'),
-    value: 'transferred_to_human_support',
-  },
-  { label: getStatusTranslation('in_progress'), value: 'in_progress' },
-  { label: getStatusTranslation('unclassified'), value: 'unclassified' },
-]);
-const statusFilter = ref(getQueryFilterArray('status', statusOptions));
-
-watch(
-  () => statusFilter.value,
-  () => {
-    supervisorStore.filters.status = statusFilter.value.map(
-      (status) => status?.value || '',
-    );
-  },
-  { immediate: true, deep: true },
-);
-
-const getCsatTranslation = (filter) =>
-  i18n.global.t(`agent_builder.supervisor.filters.csat.${filter}`);
-
-const csatOptions = computed(() => [
-  { label: getCsatTranslation('csat'), value: '' },
-  { label: getCsatTranslation('very_satisfied'), value: 'very_satisfied' },
-  { label: getCsatTranslation('satisfied'), value: 'satisfied' },
-  { label: getCsatTranslation('neutral'), value: 'neutral' },
-  { label: getCsatTranslation('dissatisfied'), value: 'dissatisfied' },
-  {
-    label: getCsatTranslation('very_dissatisfied'),
-    value: 'very_dissatisfied',
-  },
-]);
-const csatFilter = ref(getQueryFilterArray('csat', csatOptions));
-
-watch(
-  () => csatFilter.value,
-  () => {
-    supervisorStore.filters.csat = csatFilter.value.map(
-      (csat) => csat?.value || '',
-    );
-  },
-  { immediate: true, deep: true },
-);
-
-const topicOptions = computed(() => [
-  {
-    label: i18n.global.t(`agent_builder.supervisor.filters.topic.topic`),
-    value: '',
-  },
-]);
-const topicFilter = ref([]);
-
-const isRequestedTopics = ref(false);
-
-watch(
-  () => topicFilter.value,
-  async () => {
-    if (!isRequestedTopics.value) {
-      await getTopics();
-      topicFilter.value = getQueryFilterArray('topics', topicOptions);
-      isRequestedTopics.value = true;
-    }
-    supervisorStore.filters.topics = topicFilter.value.map(
-      (subject) => subject?.label || '',
-    );
-  },
-  { immediate: true, deep: true },
-);
-
-async function getTopics() {
-  await supervisorStore.getTopics().then((topics) => {
-    topicOptions.value = [
-      ...topicOptions.value,
-      ...topics.map((topic) => ({
-        label: topic.name,
-        value: topic.uuid,
-      })),
-    ];
-  });
+function applyFilters() {
+  isFilterDrawerOpen.value = false;
 }
 </script>
 
@@ -187,15 +64,13 @@ async function getTopics() {
   grid-template-columns: 8fr 4fr;
   gap: $unnnic-spacing-sm;
 
-  &__selects {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: $unnnic-spacing-sm;
+  &__drawer {
+    :deep(.unnnic-drawer__container .unnnic-drawer__content) {
+      overflow: visible;
 
-    .selects__date-picker {
-      :deep(.input) {
-        width: 100%;
-      }
+      display: flex;
+      flex-direction: column;
+      gap: $unnnic-spacing-sm;
     }
   }
 }

--- a/src/views/AgentBuilder/Supervisor/SupervisorFilters/index.vue
+++ b/src/views/AgentBuilder/Supervisor/SupervisorFilters/index.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="supervisor-filters">
-    <section class="supervisor-filters__selects">
+    <!-- <section class="supervisor-filters__selects">
       <UnnnicInputDatePicker
         v-model="dateFilter"
         position="left"
@@ -32,9 +32,17 @@
         multipleWithoutSelectsMessage
         autocomplete
       />
-    </section>
+    </section> -->
 
     <FilterText data-testid="filter-text" />
+
+    <UnnnicButton
+      iconLeft="filter_list"
+      type="secondary"
+      data-testid="filter-button"
+    >
+      {{ $t('agent_builder.supervisor.filters.filter_conversations') }}
+    </UnnnicButton>
   </section>
 </template>
 
@@ -175,8 +183,8 @@ async function getTopics() {
 
 <style scoped lang="scss">
 .supervisor-filters {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 8fr 4fr;
   gap: $unnnic-spacing-sm;
 
   &__selects {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For better positioning of the filters and scalability of the Supervisor, it was required to transport the filters to a Drawer

### Summary of Changes
<!--- Describe your changes in detail -->
- Added filter conversations button with filters count at Supervisor;
- Implement filters components separetly: FilterDate, FilterStatus, FilterCsat and FilterTopics;
- Added drawer triggered by button with clear and apply filters.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File](https://www.figma.com/design/pJtbsGz9IDNJOnHKd6qFVs/Supervisor?node-id=2229-1854&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
<img width="1601" height="228" alt="image" src="https://github.com/user-attachments/assets/9ded98ab-423a-43d8-9c70-34e0b436efac" />
<img width="1827" height="826" alt="image" src="https://github.com/user-attachments/assets/a575373a-9977-4c47-868c-bf01785c92f9" />

