### PR TITLE
[NEXUS-3836] - Enhance header styling for tunings route

### DIFF
--- a/src/components/Brain/BrainHeader.vue
+++ b/src/components/Brain/BrainHeader.vue
@@ -1,5 +1,10 @@
 <template>
-  <header class="header">
+  <header
+    :class="[
+      'header',
+      { 'header--tunings': currentBrainRoute?.page.includes('tunings') },
+    ]"
+  >
     <section class="header__infos">
       <section class="infos__title">
         <p class="title__text">
@@ -112,6 +117,10 @@ watch(
 
   & > *:only-child {
     grid-column: span 2;
+  }
+
+  &--tunings {
+    grid-template-columns: 6fr 6fr;
   }
 
   &__infos {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The size of the Tunings tab buttons was small, cutting off text inside the buttons.

### Summary of Changes
<!--- Describe your changes in detail -->
Adjusted the BrainHeader grid if on tunings route

### Demonstration <!--- (If not appropriate, remove this topic) -->
before:
<img width="1104" height="175" alt="image" src="https://github.com/user-attachments/assets/f561ec15-341b-4a83-9bc0-e510701ce4a9" />

after:
<img width="1197" height="175" alt="image" src="https://github.com/user-attachments/assets/57785725-aaf1-497c-aa70-4a2756c982a2" />
