### PR TITLE
[NEXUS-3794] - Event emission when upgrading to Multiagents

### DIFF
--- a/src/__tests__/router/router.spec.js
+++ b/src/__tests__/router/router.spec.js
@@ -3,8 +3,6 @@ import { createTestingPinia } from '@pinia/testing';
 import router from '@/router';
 import store from '@/store';
 import nexusaiAPI from '@/api/nexusaiAPI';
-import { useFeatureFlagsStore } from '@/store/FeatureFlags';
-import { useProjectStore } from '@/store/Project';
 
 vi.mock('@/views/Home.vue', () => ({
   default: {
@@ -69,15 +67,10 @@ global.location = {
 };
 
 describe('router', () => {
-  let featureFlagsStore;
-  let projectStore;
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(store, 'dispatch').mockImplementation(() => Promise.resolve());
     createTestingPinia();
-
-    featureFlagsStore = useFeatureFlagsStore();
-    projectStore = useProjectStore();
   });
 
   it('should create router with history mode', () => {
@@ -118,12 +111,6 @@ describe('router', () => {
       intelligence: 'intelligenceUuid',
     };
     vi.spyOn(nexusaiAPI.router, 'read').mockResolvedValue({ data });
-    vi.spyOn(nexusaiAPI.router.tunings.multiAgents, 'read').mockResolvedValue({
-      data: {
-        can_view: true,
-        multi_agents: true,
-      },
-    });
     const next = vi.fn();
     await router.options.routes[4].beforeEnter({}, {}, next);
     expect(store.state.router.contentBaseUuid).toBe(data.uuid);
@@ -195,47 +182,5 @@ describe('router', () => {
       .beforeEnter(to, from, next);
 
     expect(next).toHaveBeenCalled();
-  });
-
-  describe('Multi-agents feature flag', () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    it('should make a request to get multi-agents feature flag configuration before entering the router or agent builder route', async () => {
-      const next = vi.fn();
-      await router.options.routes[4].beforeEnter({}, {}, next);
-      expect(nexusaiAPI.router.tunings.multiAgents.read).toHaveBeenCalledTimes(
-        1,
-      );
-
-      await router.options.routes[5].beforeEnter({}, {}, next);
-      expect(nexusaiAPI.router.tunings.multiAgents.read).toHaveBeenCalledTimes(
-        2,
-      );
-    });
-
-    it('should not make a request before entering bothub routes', async () => {
-      const next = vi.fn();
-      await router.options.routes[3].beforeEnter({}, {}, next);
-      expect(nexusaiAPI.router.tunings.multiAgents.read).not.toHaveBeenCalled();
-    });
-
-    it('should update the multi-agents feature flag configuration when the request is successful', async () => {
-      const next = vi.fn();
-      await router.options.routes[4].beforeEnter({}, {}, next);
-      expect(featureFlagsStore.editUpgradeToMultiAgents).toHaveBeenCalledWith(
-        true,
-      );
-    });
-
-    it('should not make the request if the multi-agents project field is different of null', async () => {
-      projectStore.isMultiAgents = true;
-
-      const next = vi.fn();
-      await router.options.routes[4].beforeEnter({}, {}, next);
-
-      expect(nexusaiAPI.router.tunings.multiAgents.read).not.toHaveBeenCalled();
-    });
   });
 });

--- a/src/__tests__/store/Project.unit.spec.js
+++ b/src/__tests__/store/Project.unit.spec.js
@@ -60,37 +60,4 @@ describe('Project Store', () => {
       expect(projectStore.uuid).toBe('');
     });
   });
-
-  describe('updateIsMultiAgents action', () => {
-    it('should update isMultiAgents to true', async () => {
-      await projectStore.updateIsMultiAgents(true);
-
-      expect(projectStore.isMultiAgents).toBe(true);
-    });
-
-    it('should update isMultiAgents to false', async () => {
-      await projectStore.updateIsMultiAgents(false);
-
-      expect(projectStore.isMultiAgents).toBe(false);
-    });
-
-    it('should update isMultiAgents to null', async () => {
-      await projectStore.updateIsMultiAgents(true);
-      expect(projectStore.isMultiAgents).toBe(true);
-
-      await projectStore.updateIsMultiAgents(null);
-      expect(projectStore.isMultiAgents).toBeNull();
-    });
-
-    it('should handle non-boolean values', async () => {
-      await projectStore.updateIsMultiAgents('true');
-      expect(projectStore.isMultiAgents).toBe('true');
-
-      await projectStore.updateIsMultiAgents(1);
-      expect(projectStore.isMultiAgents).toBe(1);
-
-      await projectStore.updateIsMultiAgents(0);
-      expect(projectStore.isMultiAgents).toBe(0);
-    });
-  });
 });

--- a/src/components/Brain/Tunings/ModalUpgradeToMultiagents.vue
+++ b/src/components/Brain/Tunings/ModalUpgradeToMultiagents.vue
@@ -30,10 +30,8 @@
 <script setup>
 import { ref } from 'vue';
 import { useStore } from 'vuex';
-import { useRouter } from 'vue-router';
 
 const store = useStore();
-const router = useRouter();
 const isUpgrading = ref(false);
 const emit = defineEmits(['update:modelValue']);
 defineProps({
@@ -55,7 +53,13 @@ async function upgradeToMultiagents() {
   close();
 
   if (status === 'success') {
-    router.replace({ name: 'agents' });
+    window.parent.postMessage(
+      {
+        event: 'upgrade-to-multi-agents',
+        value: JSON.stringify(true),
+      },
+      '*',
+    );
   }
 }
 </script>

--- a/src/store/FeatureFlags.js
+++ b/src/store/FeatureFlags.js
@@ -33,11 +33,7 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
     return projectList.includes(currentProjectUuid.value);
   };
 
-  const upgradeToMultiAgents = ref(false);
-
   const flags = computed(() => ({
-    agentsTeam: useProjectStore().isMultiAgents,
-    upgradeToMultiAgents,
     supervisorExport: isProjectEnabledForFlag('FF_SUPERVISOR_EXPORT'),
     newSupervisor: growthbook?.isOn('new_supervisor'),
   }));
@@ -68,12 +64,7 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
     { immediate: true },
   );
 
-  function editUpgradeToMultiAgents(value) {
-    upgradeToMultiAgents.value = value;
-  }
-
   return {
     flags,
-    editUpgradeToMultiAgents,
   };
 });

--- a/src/store/brain/index.js
+++ b/src/store/brain/index.js
@@ -3,7 +3,6 @@ import { WENIGPT_OPTIONS } from '../../utils';
 import { models } from '@/store/brain/models.js';
 import nexusaiAPI from '@/api/nexusaiAPI.js';
 import i18n from '../../utils/plugins/i18n';
-import { useProjectStore } from '../Project';
 
 export default {
   state: () => ({
@@ -199,8 +198,6 @@ export default {
           multi_agents: true,
           hideGenericErrorAlert: true,
         });
-
-        useProjectStore().updateIsMultiAgents(true);
 
         rootState.alert = {
           type: 'success',


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With the removal of the Agent Builder 2.0 code from this repository, it was necessary to adjust how redirection to this application works. Additionally, to ensure that this application no longer loads Agent Builder 2.0, it makes sense to remove the routes associated with it (the actual files will be deleted in a future PR).

### Summary of Changes
<!--- Describe your changes in detail -->
- Removed Agent Builder 2.0 routes and the unused Agent Team feature flag.
- Replaced redirection via multiagent router navigation upgrade by sending an event via postMessage to the upgrade flow.